### PR TITLE
Add ItemsExtract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the first AI Agent: `AICodeFixer` which iteratively analyzes and improves any code provided by a LLM by evaluating it in a sandbox. It allows a lot of customization (templated responses, feedback function, etc.) See `?AICodeFixer` for more information on usage and `?aicodefixer_feedback` for the example implementation of the feedback function.
 - Added `@timeout` macro to allow for limiting the execution time of a block of code in `AICode` via `execution_timeout` kwarg (prevents infinite loops, etc.). See `?AICode` for more information.
 - Added `preview(conversation)` utility that allows you to quickly preview the conversation in a Markdown format in your REPL. Requires `Markdown` package for the extension to be loaded.
+- Added `ItemsExtract` convenience wrapper for `aiextract` when you want to extract one or more of a specific `return_type` (eg, `return_type = ItemsExtract{MyMeasurement}`)
 
 ### Fixed
 

--- a/src/extraction.jl
+++ b/src/extraction.jl
@@ -181,3 +181,10 @@ struct MaybeExtract{T <: Any}
     error::Bool
     message::Union{Nothing, String}
 end
+
+"""
+Extract zero, one or more specified items from the provided data.
+"""
+struct ItemsExtract{T <: Any}
+    items::Vector{T}
+end

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -503,7 +503,7 @@ If `return_all=true`:
 - `conversation`: A vector of `AbstractMessage` objects representing the full conversation history, including the response from the AI model (`DataMessage`).
 
 
-See also: `function_call_signature`, `MaybeExtract`, `aigenerate`
+See also: `function_call_signature`, `MaybeExtract`, `ItemsExtract`, `aigenerate`
 
 # Example
 
@@ -541,6 +541,16 @@ msg.content.measurements
 # 2-element Vector{MyMeasurement}:
 #  MyMeasurement(30, 180, 80.0)
 #  MyMeasurement(19, 190, nothing)
+```
+
+Or you can use the convenience wrapper `ItemsExtract` to extract multiple measurements (zero, one or more):
+```julia
+using PromptingTools: ItemsExtract
+
+return_type = ItemsExtract{MyMeasurement}
+msg = aiextract("James is 30, weighs 80kg. He's 180cm tall. Then Jack is 19 but really tall - over 190!"; return_type)
+
+msg.content.items # see the extracted items
 ```
 
 Or if you want your extraction to fail gracefully when data isn't found, use `MaybeExtract{T}` wrapper


### PR DESCRIPTION
Added `ItemsExtract` convenience wrapper for `aiextract` when you want to extract one or more of a specific `return_type` (eg, `return_type = ItemsExtract{MyMeasurement}`)