### PR TITLE
Add LocalServerOpenAISchema to support Llama.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Initial support for [Llama.jl](https://github.com/marcom/Llama.jl) and other local servers. Once your server is started, simply use `model="local"` to route your queries to the local server, eg, `ai"Say hi!"local`. Option to permanently set the `LOCAL_SERVER` (URL) added to preference management. See `?LocalServerOpenAISchema` for more information.
 
 ### Fixed
 

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -53,16 +53,65 @@ All user needs to do is to pass this schema as the first argument and provide th
 
 # Example
 
-Assumes that we have a local server running at `http://localhost:8081`:
+Assumes that we have a local server running at `http://127.0.0.1:8081`:
 
 ```julia
 api_key = "..."
 prompt = "Say hi!"
-msg = aigenerate(CustomOpenAISchema(), prompt; model="my_model", api_key, api_kwargs=(; url="http://localhost:8081"))
+msg = aigenerate(CustomOpenAISchema(), prompt; model="my_model", api_key, api_kwargs=(; url="http://127.0.0.1:8081"))
 ```
 
 """
 struct CustomOpenAISchema <: AbstractOpenAISchema end
+
+"""
+    LocalServerOpenAISchema
+
+Designed to be used with local servers. It's automatically called with model alias "local" (see `MODEL_REGISTRY`).
+
+This schema is a flavor of CustomOpenAISchema with a `url` key` preset by global Preference key `LOCAL_SERVER`. See `?PREFERENCES` for more details on how to change it.
+It assumes that the server follows OpenAI API conventions (eg, `POST /v1/chat/completions`).
+
+Note: Llama.cpp (and hence Llama.jl built on top of it) do NOT support embeddings endpoint! You'll get an address error.
+
+# Example
+
+Assumes that we have a local server running at `http://127.0.0.1:10897/v1` (port and address used by Llama.jl, "v1" at the end is needed for OpenAI endpoint compatibility):
+
+Three ways to call it:
+```julia
+
+# Use @ai_str with "local" alias
+ai"Say hi!"local
+
+# model="local"
+aigenerate("Say hi!"; model="local")
+
+# Or set schema explicitly
+const PT = PromptingTools
+msg = aigenerate(PT.LocalServerOpenAISchema(), "Say hi!")
+```
+
+How to start a LLM local server? You can use `run_server` function from [Llama.jl](https://github.com/marcom/Llama.jl). Use a separate Julia session.
+```julia
+using Llama
+model = "...path..." # see Llama.jl README how to download one
+run_server(; model)
+```
+
+To change the default port and address:
+```julia
+# For a permanent change, set the preference:
+using Preferences
+set_preferences!("LOCAL_SERVER"=>"http://127.0.0.1:10897/v1")
+
+# Or if it's a temporary fix, just change the variable `LOCAL_SERVER`:
+const PT = PromptingTools
+PT.LOCAL_SERVER = "http://127.0.0.1:10897/v1"
+```
+
+"""
+struct LocalServerOpenAISchema <: AbstractOpenAISchema end
 
 """
     MistralOpenAISchema

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -121,6 +121,26 @@ function OpenAI.create_chat(schema::CustomOpenAISchema,
 end
 
 """
+    OpenAI.create_chat(schema::LocalServerOpenAISchema,
+        api_key::AbstractString,
+        model::AbstractString,
+        conversation;
+        url::String = "http://localhost:8080",
+        kwargs...)
+
+Dispatch to the OpenAI.create_chat function, but with the LocalServer API parameters, ie, defaults to `url` specified by the `LOCAL_SERVER` preference. See `?PREFERENCES`
+
+"""
+function OpenAI.create_chat(schema::LocalServerOpenAISchema,
+        api_key::AbstractString,
+        model::AbstractString,
+        conversation;
+        url::String = LOCAL_SERVER,
+        kwargs...)
+    OpenAI.create_chat(CustomOpenAISchema(), api_key, model, conversation; url, kwargs...)
+end
+
+"""
     OpenAI.create_chat(schema::MistralOpenAISchema,
   api_key::AbstractString,
   model::AbstractString,
@@ -171,6 +191,22 @@ function OpenAI.create_embeddings(schema::CustomOpenAISchema,
     # Create chat will automatically pass our data to endpoint `/embeddings`
     provider = CustomProvider(; api_key, base_url = url)
     OpenAI.create_embeddings(provider, docs, model; kwargs...)
+end
+# Set url and just forward to CustomOpenAISchema otherwise
+# Note: Llama.cpp and hence Llama.jl DO NOT support the embeddings endpoint !! (they use `/embedding`)
+function OpenAI.create_embeddings(schema::LocalServerOpenAISchema,
+        api_key::AbstractString,
+        docs,
+        model::AbstractString;
+        ## Strip the "v1" from the end of the url
+        url::String = LOCAL_SERVER,
+        kwargs...)
+    OpenAI.create_embeddings(CustomOpenAISchema(),
+        api_key,
+        docs,
+        model;
+        url,
+        kwargs...)
 end
 function OpenAI.create_embeddings(schema::MistralOpenAISchema,
         api_key::AbstractString,


### PR DESCRIPTION
Initial support for [Llama.jl](https://github.com/marcom/Llama.jl) and other local servers. Once your server is started, simply use `model="local"` to route your queries to the local server, eg, `ai"Say hi!"local`. Option to permanently set the `LOCAL_SERVER` (URL) added to preference management. See `?LocalServerOpenAISchema` for more information.

Three ways to call it:
```julia

# Use @ai_str with "local" alias
ai"Say hi!"local

# model="local"
aigenerate("Say hi!"; model="local")

# Or set schema explicitly
const PT = PromptingTools
msg = aigenerate(PT.LocalServerOpenAISchema(), "Say hi!")
```

Embedding endpoint is not supported for Llama.cpp / Llama.jl, because it's not OpenAI-API-compatible (it uses custom semantics). [Use it directly](https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md) if you need it.