### PR TITLE
Add Databricks API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.11.0]
+
+### Added
+- Support for [Databricks Foundation Models API](https://docs.databricks.com/en/machine-learning/foundation-models/index.html). Requires two environment variables to be set: `DATABRICKS_API_KEY` and `DATABRICKS_HOST` (the part of the URL before `/serving-endpoints/`)
+
+### Fixed
+
 ## [0.10.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.10.0"
+version = "0.11.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/examples/working_with_custom_apis.md
+++ b/docs/src/examples/working_with_custom_apis.md
@@ -67,3 +67,34 @@ msg = aigenerate(PT.CustomOpenAISchema(), "Count to 5 and say hi!"; api_kwargs=(
 
 > [!TIP]
 > If you register the model names with `PT.register_model!`, you won't have to keep providing the `schema` manually. It can be any `model` name, because the model is actually selected when you start the server in the terminal.
+
+## Using Databricks Foundation Models
+
+You can also use the Databricks Foundation Models API with PromptingTools.jl. 
+It requires you to set ENV variables `DATABRICKS_API_KEY` (often referred to as "DATABRICKS TOKEN") and `DATABRICKS_HOST`.
+
+The long way to use it is:
+```julia
+msg = aigenerate(PT.DatabricksOpenAISchema(),
+    "Say hi to the llama!";
+    model = "databricks-llama-2-70b-chat",
+    api_key = ENV["DATABRICKS_API_KEY"], api_kwargs = (; url=ENV["DATABRICKS_HOST"]))
+```
+
+But you can also register the models you're hosting and use it as usual:
+```julia
+# Quick registration of a model
+PT.register_model!(;
+        name = "databricks-llama-2-70b-chat",
+        schema = PT.DatabricksOpenAISchema())
+PT.MODEL_ALIASES["dllama"] = "databricks-llama-2-70b-chat" # set alias to make your life easier
+
+# Simply call:
+msg = aigenerate("Say hi to the llama!"; model = "dllama")
+# Or even shorter
+ai"Say hi to the llama!"dllama
+```
+
+You can use `aiembed` as well.
+
+Find more information [here](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html).

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -135,6 +135,17 @@ See `?PREFERENCES` for more details on how to set your API key permanently.
 """
 struct MistralOpenAISchema <: AbstractOpenAISchema end
 
+"""
+    DatabricksOpenAISchema
+
+DatabricksOpenAISchema() allows user to call Databricks Foundation Model API. [API Reference](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html)
+
+Requires two environment variables to be set:
+- `DATABRICKS_API_KEY`: Databricks token
+- `DATABRICKS_HOST`: Address of the Databricks workspace (`https://<workspace_host>.databricks.com`)
+"""
+struct DatabricksOpenAISchema <: AbstractOpenAISchema end
+
 abstract type AbstractOllamaSchema <: AbstractPromptSchema end
 
 """

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -165,6 +165,24 @@ function OpenAI.create_chat(schema::MistralOpenAISchema,
         base_url = url)
     OpenAI.create_chat(provider, model, conversation; kwargs...)
 end
+function OpenAI.create_chat(schema::DatabricksOpenAISchema,
+        api_key::AbstractString,
+        model::AbstractString,
+        conversation;
+        url::String = "https://<workspace_host>.databricks.com",
+        kwargs...)
+    # Build the corresponding provider object
+    provider = CustomProvider(;
+        api_key = isempty(DATABRICKS_API_KEY) ? api_key : DATABRICKS_API_KEY,
+        base_url = isempty(DATABRICKS_HOST) ? url : DATABRICKS_HOST)
+    # Override standard OpenAI request endpoint
+    OpenAI.openai_request("serving-endpoints/$model/invocations",
+        provider;
+        method = "POST",
+        model,
+        messages = conversation,
+        kwargs...)
+end
 
 # Extend OpenAI create_embeddings to allow for testing
 function OpenAI.create_embeddings(schema::AbstractOpenAISchema,
@@ -220,6 +238,24 @@ function OpenAI.create_embeddings(schema::MistralOpenAISchema,
         api_key = isempty(MISTRALAI_API_KEY) ? api_key : MISTRALAI_API_KEY,
         base_url = url)
     OpenAI.create_embeddings(provider, docs, model; kwargs...)
+end
+function OpenAI.create_embeddings(schema::DatabricksOpenAISchema,
+        api_key::AbstractString,
+        docs,
+        model::AbstractString;
+        url::String = "https://<workspace_host>.databricks.com",
+        kwargs...)
+    # Build the corresponding provider object
+    provider = CustomProvider(;
+        api_key = isempty(DATABRICKS_API_KEY) ? api_key : DATABRICKS_API_KEY,
+        base_url = isempty(DATABRICKS_HOST) ? url : DATABRICKS_HOST)
+    # Override standard OpenAI request endpoint
+    OpenAI.openai_request("serving-endpoints/$model/invocations",
+        provider;
+        method = "POST",
+        model,
+        input = docs,
+        kwargs...)
 end
 
 ## Temporary fix -- it will be moved upstream

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -14,6 +14,8 @@ Check your preferences by calling `get_preferences(key::String)`.
 - `OPENAI_API_KEY`: The API key for the OpenAI API. See [OpenAI's documentation](https://platform.openai.com/docs/quickstart?context=python) for more information.
 - `MISTRALAI_API_KEY`: The API key for the Mistral AI API. See [Mistral AI's documentation](https://docs.mistral.ai/) for more information.
 - `COHERE_API_KEY`: The API key for the Cohere API. See [Cohere's documentation](https://docs.cohere.com/docs/the-cohere-platform) for more information.
+- `DATABRICKS_API_KEY`: The API key for the Databricks Foundation Model API. See [Databricks' documentation](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html) for more information.
+- `DATABRICKS_HOST`: The host for the Databricks API. See [Databricks' documentation](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html) for more information.
 - `MODEL_CHAT`: The default model to use for aigenerate and most ai* calls. See `MODEL_REGISTRY` for a list of available models or define your own.
 - `MODEL_EMBEDDING`: The default model to use for aiembed (embedding documents). See `MODEL_REGISTRY` for a list of available models or define your own.
 - `PROMPT_SCHEMA`: The default prompt schema to use for aigenerate and most ai* calls (if not specified in `MODEL_REGISTRY`). Set as a string, eg, `"OpenAISchema"`.
@@ -33,6 +35,8 @@ Define your `register_model!()` calls in your `startup.jl` file to make them ava
 - `MISTRALAI_API_KEY`: The API key for the Mistral AI API.
 - `COHERE_API_KEY`: The API key for the Cohere API.
 - `LOCAL_SERVER`: The URL of the local server to use for `ai*` calls. Defaults to `http://localhost:10897/v1`. This server is called when you call `model="local"`
+- `DATABRICKS_API_KEY`: The API key for the Databricks Foundation Model API.
+- `DATABRICKS_HOST`: The host for the Databricks API.
 
 Preferences.jl takes priority over ENV variables, so if you set a preference, it will override the ENV variable.
 
@@ -59,6 +63,8 @@ function set_preferences!(pairs::Pair{String, <:Any}...)
         "MISTRALAI_API_KEY",
         "OPENAI_API_KEY",
         "COHERE_API_KEY",
+        "DATABRICKS_API_KEY",
+        "DATABRICKS_HOST",
         "MODEL_CHAT",
         "MODEL_EMBEDDING",
         "MODEL_ALIASES",
@@ -95,6 +101,8 @@ function get_preferences(key::String)
         "MISTRALAI_API_KEY",
         "OPENAI_API_KEY",
         "COHERE_API_KEY",
+        "DATABRICKS_API_KEY",
+        "DATABRICKS_HOST",
         "MODEL_CHAT",
         "MODEL_EMBEDDING",
         "MODEL_ALIASES",
@@ -114,20 +122,26 @@ const MODEL_EMBEDDING::String = @load_preference("MODEL_EMBEDDING",
 # const PROMPT_SCHEMA = OpenAISchema()
 
 # First, load from preferences, then from environment variables
-const OPENAI_API_KEY::String = @load_preference("OPENAI_API_KEY",
+const OPENAI_API_KEY::String = @noinline @load_preference("OPENAI_API_KEY",
     default=@noinline get(ENV, "OPENAI_API_KEY", ""));
 # Note: Disable this warning by setting OPENAI_API_KEY to anything
 isempty(OPENAI_API_KEY) &&
     @warn "OPENAI_API_KEY variable not set! OpenAI models will not be available - set API key directly via `PromptingTools.OPENAI_API_KEY=<api-key>`!"
 
-const MISTRALAI_API_KEY::String = @load_preference("MISTRALAI_API_KEY",
+const MISTRALAI_API_KEY::String = @noinline @load_preference("MISTRALAI_API_KEY",
     default=@noinline get(ENV, "MISTRALAI_API_KEY", ""));
 
-const COHERE_API_KEY::String = @load_preference("COHERE_API_KEY",
+const COHERE_API_KEY::String = @noinline @load_preference("COHERE_API_KEY",
     default=@noinline get(ENV, "COHERE_API_KEY", ""));
 
+const DATABRICKS_API_KEY::String = @noinline @load_preference("DATABRICKS_API_KEY",
+    default=@noinline get(ENV, "DATABRICKS_API_KEY", ""));
+
+const DATABRICKS_HOST::String = @noinline @load_preference("DATABRICKS_HOST",
+    default=@noinline get(ENV, "DATABRICKS_HOST", ""));
+
 ## Address of the local server
-const LOCAL_SERVER::String = @load_preference("LOCAL_SERVER",
+const LOCAL_SERVER::String = @noinline @load_preference("LOCAL_SERVER",
     default=@noinline get(ENV, "LOCAL_SERVER", "http://127.0.0.1:10897/v1"));
 
 ## CONVERSATION HISTORY


### PR DESCRIPTION
- Support for [Databricks Foundation Models API](https://docs.databricks.com/en/machine-learning/foundation-models/index.html). Requires two environment variables to be set: `DATABRICKS_API_KEY` and `DATABRICKS_HOST` (the part of the URL before `/serving-endpoints/`)