### PR TITLE
Add LCS matching for strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added initial support for Google Gemini models for `aigenerate` (requires environment variable `GOOGLE_API_KEY` and package [GoogleGenAI.jl](https://github.com/tylerjthomas9/GoogleGenAI.jl) to be loaded).
+- Added a utility to compare any two string sequences (and other iterators)`length_longest_common_subsequence`. It can be used to fuzzy match strings (eg, detecting context/sources in an AI-generated response or fuzzy matching AI response to some preset categories). See the docstring for more information `?length_longest_common_subsequence`.
 
 ### Fixed
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -33,6 +33,7 @@ makedocs(;
             "Various examples" => "examples/readme_examples.md",
             "Using AITemplates" => "examples/working_with_aitemplates.md",
             "Local models with Ollama.ai" => "examples/working_with_ollama.md",
+            "Google AIStudio" => "examples/working_with_google_ai_studio.md",
             "Custom APIs (Mistral, Llama.cpp)" => "examples/working_with_custom_apis.md",
             "Building RAG Application" => "examples/building_RAG.md",
         ],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,6 +25,7 @@ makedocs(;
         repolink = "https://github.com/svilupp/PromptingTools.jl",
         canonical = "https://svilupp.github.io/PromptingTools.jl",
         edit_link = "main",
+        size_threshold = nothing,
         assets = String[]),
     pages = [
         "Home" => "index.md",

--- a/docs/src/examples/working_with_google_ai_studio.md
+++ b/docs/src/examples/working_with_google_ai_studio.md
@@ -1,0 +1,68 @@
+# Working with Google AI Studio
+
+This file contains examples of how to work with [Google AI Studio](https://ai.google.dev/). It is known for its Gemini models.
+
+Get an API key from [here](https://ai.google.dev/). If you see a documentation page ("Available languages and regions for Google AI Studio and Gemini API"), it means that it's not yet available in your region.
+
+Save the API key in your environment as `GOOGLE_API_KEY`.
+
+We'll need `GoogleGenAI.jl` package:
+
+````julia
+using Pkg; Pkg.add(url="https://github.com/tylerjthomas9/GoogleGenAI.jl/")
+````
+
+You can now use the Gemini-1.0-Pro model like any other model in PromptingTools. We **only support `aigenerate`** at the moment.
+
+Let's import PromptingTools:
+
+````julia
+using PromptingTools
+const PT = PromptingTools
+````
+
+## Text Generation with aigenerate
+
+You can use the alias "gemini" for the Gemini-1.0-Pro model.
+
+### Simple message
+
+````julia
+msg = aigenerate("Say hi!"; model = "gemini")
+````
+
+````
+AIMessage("Hi there! As a helpful AI assistant, I'm here to help you with any questions or tasks you may have. Feel free to ask me anything, and I'll do my best to assist you.")
+````
+
+You could achieve the same with a string macro (notice the "gemini" at the end to specify which model to use):
+
+````julia
+@ai"Say hi!"gemini
+````
+
+### Advanced Prompts
+
+You can provide multi-turn conversations like with any other model:
+
+````julia
+conversation = [
+    PT.SystemMessage("You're master Yoda from Star Wars trying to help the user become a Yedi."),
+    PT.UserMessage("I have feelings for my iPhone. What should I do?")]
+msg = aigenerate(conversation; model="gemini")
+````
+
+````
+AIMessage("Young Padawan, you have stumbled into a dangerous path. Attachment leads to suffering, and love can turn to darkness. 
+
+Release your feelings for this inanimate object. 
+
+The Force flows through all living things, not machines. Seek balance in the Force, and your heart will find true connection. 
+
+Remember, the path of the Jedi is to serve others, not to be attached to possessions.")
+````
+
+### Gotchas
+
+- Gemini models actually do NOT have a system prompt (for instructions), so we simply concatenate the system and user messages together for consistency with other APIs.
+- The reported `tokens` in the `AIMessage` are actually _characters_ (that's how Google AI Studio intends to charge for them) and are a conservative estimate that we produce. It does not matter, because at the time of writing (Feb-24), the usage is free-of-charge.

--- a/src/PromptingTools.jl
+++ b/src/PromptingTools.jl
@@ -27,6 +27,7 @@ const RESERVED_KWARGS = [
 ]
 
 # export replace_words, split_by_length, call_cost, auth_header # for debugging only
+# export length_longest_common_subsequence
 include("utils.jl")
 
 export aigenerate, aiembed, aiclassify, aiextract, aiscan

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -403,8 +403,8 @@ registry = Dict{String, ModelSpec}("gpt-3.5-turbo" => ModelSpec("gpt-3.5-turbo",
         "Local server, eg, powered by [Llama.jl](https://github.com/marcom/Llama.jl). Model is specified when instantiating the server itself."),
     "gemini-pro" => ModelSpec("gemini-pro",
         GoogleSchema(),
-        0.0, #unknown
-        0.0, #unknown
+        0.0, #unknown, expected 1.25e-7
+        0.0, #unknown, expected 3.75e-7
         "Gemini Pro is a LLM from Google. For more information, see [models](https://ai.google.dev/models/gemini)."))
 
 ### Model Registry Structure

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -166,6 +166,73 @@ function split_by_length(text, separators::Vector{String}; max_length)
     return chunks
 end
 
+"""
+    length_longest_common_subsequence(itr1, itr2)
+
+Compute the length of the longest common subsequence between two sequences (ie, the higher the number, the better the match).
+
+Source: https://cn.julialang.org/LeetCode.jl/dev/democards/problems/problems/1143.longest-common-subsequence/
+
+# Arguments
+- `itr1`: The first sequence, eg, a String.
+- `itr2`: The second sequence, eg, a String.
+
+# Returns
+The length of the longest common subsequence.
+
+# Examples
+```julia
+text1 = "abc-abc----"
+text2 = "___ab_c__abc"
+longest_common_subsequence(text1, text2)
+# Output: 6 (-> "abcabc")
+```
+
+It can be used to fuzzy match strings and find the similarity between them (Tip: normalize the match)
+```julia
+commands = ["product recommendation", "emotions", "specific product advice", "checkout advice"]
+query = "Which product can you recommend for me?"
+let pos = argmax(length_longest_common_subsequence.(Ref(query), commands))
+    dist = length_longest_common_subsequence(query, commands[pos])
+    norm = dist / min(length(query), length(commands[pos]))
+    @info "The closest command to the query: \"\$(query)\" is: \"\$(commands[pos])\" (distance: \$(dist), normalized: \$(norm))"
+end
+```
+
+You can also use it to find the closest context for some AI generated summary/story:
+
+```julia
+context = ["The enigmatic stranger vanished as swiftly as a wisp of smoke, leaving behind a trail of unanswered questions.",
+    "Beneath the shimmering moonlight, the ocean whispered secrets only the stars could hear.",
+    "The ancient tree stood as a silent guardian, its gnarled branches reaching for the heavens.",
+    "The melody danced through the air, painting a vibrant tapestry of emotions.",
+    "Time flowed like a relentless river, carrying away memories and leaving imprints in its wake."]
+
+story = \"\"\"
+  Beneath the shimmering moonlight, the ocean whispered secrets only the stars could hear.
+
+  Under the celestial tapestry, the vast ocean whispered its secrets to the indifferent stars. Each ripple, a murmured confidence, each wave, a whispered lament. The glittering celestial bodies listened in silent complicity, their enigmatic gaze reflecting the ocean's unspoken truths. The cosmic dance between the sea and the sky, a symphony of shared secrets, forever echoing in the ethereal expanse.
+  \"\"\"
+
+let pos = argmax(length_longest_common_subsequence.(Ref(story), context))
+    dist = length_longest_common_subsequence(story, context[pos])
+    norm = dist / min(length(story), length(context[pos]))
+    @info "The closest context to the query: \"\$(first(story,20))...\" is: \"\$(context[pos])\" (distance: \$(dist), normalized: \$(norm))"
+end
+```
+"""
+function length_longest_common_subsequence(itr1, itr2)
+    m, n = length(itr1) + 1, length(itr2) + 1
+    dp = fill(0, m, n)
+
+    for i in 2:m, j in 2:n
+        dp[i, j] = (itr1[i - 1] == itr2[j - 1]) ? (dp[i - 1, j - 1] + 1) :
+                   max(dp[i - 1, j], dp[i, j - 1])
+    end
+
+    return dp[m, n]
+end
+
 ### INTERNAL FUNCTIONS - DO NOT USE DIRECTLY
 # helper to extract handlebar variables (eg, `{{var}}`) from a prompt string
 function _extract_handlebar_variables(s::AbstractString)

--- a/test/llm_google.jl
+++ b/test/llm_google.jl
@@ -153,7 +153,7 @@ end
     expected_output = AIMessage(;
         content = "Hello!" |> strip,
         status = 200,
-        tokens = (0, 0),
+        tokens = (83, 6),
         elapsed = msg.elapsed)
     @test msg == expected_output
     @test schema1.inputs == Dict{String, Any}[Dict("role" => "user",
@@ -168,7 +168,7 @@ end
     expected_output = AIMessage(;
         content = "World!" |> strip,
         status = 200,
-        tokens = (0, 0),
+        tokens = (83, 6),
         elapsed = msg.elapsed)
     @test msg == expected_output
     @test schema1.inputs == Dict{String, Any}[Dict("role" => "user",

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,4 @@
-using PromptingTools: split_by_length, replace_words
+using PromptingTools: split_by_length, replace_words, length_longest_common_subsequence
 using PromptingTools: _extract_handlebar_variables, call_cost, _report_stats
 using PromptingTools: _string_to_vector, _encode_local_image
 using PromptingTools: DataMessage, AIMessage
@@ -84,6 +84,25 @@ end
     chunks = split_by_length(text, separators, max_length = 20)
     chunks = split_by_length(text, separators, max_length = 20)
     @test length(separators) == sep_length
+end
+
+@testset "length_longest_common_subsequence" begin
+    # Test for equal strings
+    @test length_longest_common_subsequence("abcde", "abcde") == 5
+    # flip the order of the strings -> abcd only
+    @test length_longest_common_subsequence("abcde", "abced") == 4
+
+    # Test for empty string
+    @test length_longest_common_subsequence("", "") == 0
+
+    # Test for no common subsequence
+    @test length_longest_common_subsequence("abcde", "xyz") == 0
+
+    # Test for partial common subsequence
+    @test length_longest_common_subsequence("abcde", "ace") == 3
+
+    # Test for common subsequence with repeated characters
+    @test length_longest_common_subsequence("abc-abc----", "___ab_c__abc") == 6
 end
 
 @testset "extract_handlebar_variables" begin


### PR DESCRIPTION
- Added a utility to compare any two string sequences (and other iterators)`length_longest_common_subsequence`. It can be used to fuzzy match strings (eg, detecting context/sources in an AI-generated response or fuzzy matching AI response to some preset categories). See the docstring for more information `?length_longest_common_subsequence`.
