### PR TITLE
Export non-echo schemas

### DIFF
--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -6,6 +6,14 @@
 #
 # Ideally, each new interface would be defined in a separate `llm_<interface>.jl` file (eg, `llm_chatml.jl`).
 
+# Add exports for each schema
+export NoSchema
+export OpenAISchema, CustomOpenAISchema, LocalServerOpenAISchema, DatabricksOpenAISchema
+export MistralOpenAISchema
+export OllamaManagedSchema, OllamaSchema
+export ChatMLSchema
+export GoogleSchema
+
 ## Main Functions
 function render end
 function aigenerate end


### PR DESCRIPTION
Mostly a convenience PR to permit direct schema access. I typically use Ollama exclusively, so it's nice to be able to do

```julia
aigenerate(OllamaSchema(), ...)
```

instead of 

```julia
aigenerate(PromptingTools.OllamaSchema(), ...)
```