### PR TITLE
Multiple competions (`n`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added initial support for Google Gemini models for `aigenerate` (requires environment variable `GOOGLE_API_KEY` and package [GoogleGenAI.jl](https://github.com/tylerjthomas9/GoogleGenAI.jl) to be loaded).
 - Added a utility to compare any two string sequences (and other iterators)`length_longest_common_subsequence`. It can be used to fuzzy match strings (eg, detecting context/sources in an AI-generated response or fuzzy matching AI response to some preset categories). See the docstring for more information `?length_longest_common_subsequence`.
-- Rewrite of `aiclassify` to classify into an arbitrary list of categories (including with descriptions). It's a quick and easy option for "routing" and similar use cases, as it exploits the logit bias trick and outputs only 1 token. Currently only `OpenAISchema` is supported. See `?aiclassify` for more information.
+- Rewrite of `aiclassify` to classify into an arbitrary list of categories (including with descriptions). It's a quick and easy option for "routing" and similar use cases, as it exploits the logit bias trick and outputs only 1 token. Currently, only `OpenAISchema` is supported. See `?aiclassify` for more information.
+- Initial support for multiple completions in one request for OpenAI-compatible API servers. Set via API kwarg `n=5` and it will request 5 completions in one request, saving the network communication time and paying the prompt tokens only once. It's useful for majority voting, diversity, or challenging agentic workflows.
+- Added new fields to `AIMessage` and `DataMessage` types to simplify tracking in complex applications. Added fields: 
+  - `cost` - the cost of the query (summary per call, so count only once if you requested multiple completions in one call)
+  - `log_prob` - summary log probability of the generated sequence, set API kwarg `logprobs=true` to receive it
+  - `run_id`  - ID of the AI API call
+  - `sample_id` - ID of the sample in the batch if you requested multiple completions, otherwise `sample_id==nothing` (they will have the same `run_id`)
+  - `finish_reason` - the reason why the AI stopped generating the sequence (eg, "stop", "length") to provide more visibility for the user
 
 ### Fixed
 

--- a/src/Experimental/AgentTools/lazy_types.jl
+++ b/src/Experimental/AgentTools/lazy_types.jl
@@ -62,6 +62,8 @@ This can be used to "reply" to previous message / continue the stored conversati
     success::Union{Nothing, Bool} = nothing
     error::Union{Nothing, Exception} = nothing
 end
+## main sample
+## samples
 
 function AICall(func::F, args...; kwargs...) where {F <: Function}
     @assert length(args)<=2 "AICall takes at most 2 positional arguments (provided: $(length(args)))"

--- a/src/Experimental/RAGTools/types.jl
+++ b/src/Experimental/RAGTools/types.jl
@@ -8,6 +8,19 @@ abstract type AbstractChunkIndex <: AbstractDocumentIndex end
 # More advanced index would be: HybridChunkIndex
 
 # Stores document chunks and their embeddings
+"""
+    ChunkIndex
+
+Main struct for storing document chunks and their embeddings. It also stores tags and sources for each chunk.
+
+# Fields
+- `id::Symbol`: unique identifier of each index (to ensure we're using the right index with `CandidateChunks`)
+- `chunks::Vector{<:AbstractString}`: underlying document chunks / snippets
+- `embeddings::Union{Nothing, Matrix{<:Real}}`: for semantic search
+- `tags::Union{Nothing, AbstractMatrix{<:Bool}}`: for exact search, filtering, etc. This is often a sparse matrix indicating which chunks have the given `tag` (see `tag_vocab` for the position lookup)
+- `tags_vocab::Union{Nothing, Vector{<:AbstractString}}`: vocabulary for the `tags` matrix (each column in `tags` is one item in `tags_vocab` and rows are the chunks)
+- `sources::Vector{<:AbstractString}`: sources of the chunks
+"""
 @kwdef struct ChunkIndex{
     T1 <: AbstractString,
     T2 <: Union{Nothing, Matrix{<:Real}},

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -250,3 +250,16 @@ function aiscan(prompt; model = MODEL_CHAT, kwargs...)
     schema = get(MODEL_REGISTRY, model, (; schema = PROMPT_SCHEMA)).schema
     aiscan(schema, prompt; model, kwargs...)
 end
+
+"Utility to facilitate unwrapping of HTTP response to a message type `MSG` provided. Designed to handle multi-sample completions."
+function response_to_message(schema::AbstractPromptSchema,
+        MSG::Type{T},
+        choice,
+        resp;
+        return_type = nothing,
+        model_id::AbstractString = "",
+        time::Float64 = 0.0,
+        run_id::Integer = rand(Int16),
+        sample_id::Union{Nothing, Integer} = nothing) where {T}
+    throw(ArgumentError("Response unwrapping not implemented for $(typeof(schema)) and $MSG"))
+end

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -285,6 +285,8 @@ end
 
 Utility to facilitate unwrapping of HTTP response to a message type `MSG` provided for OpenAI-like responses
 
+Note: Extracts `finish_reason` and `log_prob` if available in the response.
+
 # Arguments
 - `schema::AbstractOpenAISchema`: The schema for the prompt.
 - `MSG::Type{AIMessage}`: The message type to be returned.
@@ -301,11 +303,15 @@ function response_to_message(schema::AbstractOpenAISchema,
         resp;
         model_id::AbstractString = "",
         time::Float64 = 0.0,
-        run_id::Int = Int(rand(Int16)),
+        run_id::Int = Int(rand(Int32)),
         sample_id::Union{Nothing, Integer} = nothing)
     ## extract sum log probability
-    log_prob = if haskey(choice, :logprobs)
-        sum([c[:logprob] for c in choice[:logprobs][:content]])
+    has_log_prob = haskey(choice, :logprobs) &&
+                   !isnothing(get(choice, :logprobs, nothing)) &&
+                   haskey(choice[:logprobs], :content) &&
+                   !isnothing(choice[:logprobs][:content])
+    log_prob = if has_log_prob
+        sum([get(c, :logprob, 0.0) for c in choice[:logprobs][:content]])
     else
         nothing
     end
@@ -321,7 +327,7 @@ function response_to_message(schema::AbstractOpenAISchema,
         run_id,
         sample_id,
         log_prob,
-        finish_reason = choice[:finish_reason],
+        finish_reason = get(choice, :finish_reason, nothing),
         tokens = (tokens_prompt,
             tokens_completion),
         elapsed = time)
@@ -350,7 +356,11 @@ Generate an AI response based on a given prompt using the OpenAI API.
 - `dry_run::Bool=false`: If `true`, skips sending the messages to the model (for debugging, often used with `return_all=true`).
 - `conversation`: An optional vector of `AbstractMessage` objects representing the conversation history. If not provided, it is initialized as an empty vector.
 - `http_kwargs`: A named tuple of HTTP keyword arguments.
-- `api_kwargs`: A named tuple of API keyword arguments.
+- `api_kwargs`: A named tuple of API keyword arguments. Useful parameters include:
+    - `temperature`: A float representing the temperature for sampling (ie, the amount of "creativity"). Often defaults to `0.7`.
+    - `logprobs`: A boolean indicating whether to return log probabilities for each token. Defaults to `false`.
+    - `n`: An integer representing the number of completions to generate at once (if supported).
+    - `stop`: A vector of strings representing the stop conditions for the conversation. Defaults to an empty vector.
 - `kwargs`: Prompt variables to be used to fill the prompt/template
 
 # Returns
@@ -421,7 +431,7 @@ function aigenerate(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_
             api_kwargs...)
         ## Process one of more samples returned
         msg = if length(r.response[:choices]) > 1
-            run_id = Int(rand(Int16)) # remember one run ID
+            run_id = Int(rand(Int32)) # remember one run ID
             ## extract all message
             msgs = [response_to_message(prompt_schema, AIMessage, choice, r;
                 time, model_id, run_id, sample_id = i)
@@ -522,7 +532,6 @@ function aiembed(prompt_schema::AbstractOpenAISchema,
     global MODEL_ALIASES
     ## Find the unique ID for the model alias provided
     model_id = get(MODEL_ALIASES, model, model)
-
     time = @elapsed r = create_embeddings(prompt_schema, api_key,
         doc_or_docs,
         model_id;
@@ -531,6 +540,7 @@ function aiembed(prompt_schema::AbstractOpenAISchema,
     msg = DataMessage(;
         content = mapreduce(x -> postprocess(x[:embedding]), hcat, r.response[:data]),
         status = Int(r.status),
+        cost = call_cost(r.response[:usage][:prompt_tokens], 0, model_id),
         tokens = (r.response[:usage][:prompt_tokens], 0),
         elapsed = time)
     ## Reporting
@@ -653,8 +663,15 @@ function decode_choices(schema::TestEchoOpenAISchema,
 end
 
 function decode_choices(schema::OpenAISchema, choices, conv::AbstractVector; kwargs...)
-    if length(conv) > 0 && last(conv) isa AIMessage
-        conv[end] = decode_choices(schema, choices, last(conv))
+    if length(conv) > 0 && last(conv) isa AIMessage && hasproperty(last(conv), :run_id)
+        ## if it is a multi-sample response, 
+        ## Remember its run ID and convert all samples in that run
+        run_id = last(conv).run_id
+        for i in eachindex(conv)
+            if conv[i].run_id == run_id
+                conv[i] = decode_choices(schema, choices, conv[i])
+            end
+        end
     end
     return conv
 end
@@ -683,7 +700,8 @@ function decode_choices(schema::OpenAISchema,
         ## failed decoding
         content = nothing
     end
-    return AIMessage(; content, msg.status, msg.tokens, msg.elapsed)
+    ## create a new object with all the same fields except for content
+    return AIMessage(; [f => getfield(msg, f) for f in fieldnames(typeof(msg))]..., content)
 end
 
 """
@@ -767,6 +785,53 @@ function aiclassify(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_
         api_kwargs,
         kwargs...)
     return decode_choices(prompt_schema, decode_ids, msg_or_conv)
+end
+
+function response_to_message(schema::AbstractOpenAISchema,
+        MSG::Type{DataMessage},
+        choice,
+        resp;
+        return_type = nothing,
+        model_id::AbstractString = "",
+        time::Float64 = 0.0,
+        run_id::Int = Int(rand(Int32)),
+        sample_id::Union{Nothing, Integer} = nothing)
+    @assert !isnothing(return_type) "You must provide a return_type for DataMessage construction"
+    ## extract sum log probability
+    has_log_prob = haskey(choice, :logprobs) &&
+                   !isnothing(get(choice, :logprobs, nothing)) &&
+                   haskey(choice[:logprobs], :content) &&
+                   !isnothing(choice[:logprobs][:content])
+    log_prob = if has_log_prob
+        sum([get(c, :logprob, 0.0) for c in choice[:logprobs][:content]])
+    else
+        nothing
+    end
+    ## calculate cost
+    tokens_prompt = resp.response[:usage][:prompt_tokens]
+    tokens_completion = resp.response[:usage][:completion_tokens]
+    cost = call_cost(tokens_prompt, tokens_completion, model_id)
+    # "Safe" parsing of the response - it still fails if JSON is invalid
+    content = try
+        choice[:message][:tool_calls][1][:function][:arguments] |>
+        x -> JSON3.read(x, return_type)
+    catch e
+        @warn "There was an error parsing the response: $e. Using the raw response instead."
+        choice[:message][:tool_calls][1][:function][:arguments] |>
+        JSON3.read |> copy
+    end
+    ## build DataMessage object
+    msg = MSG(;
+        content = content,
+        status = Int(resp.status),
+        cost,
+        run_id,
+        sample_id,
+        log_prob,
+        finish_reason = get(choice, :finish_reason, nothing),
+        tokens = (tokens_prompt,
+            tokens_completion),
+        elapsed = time)
 end
 
 """
@@ -901,10 +966,12 @@ function aiextract(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_T
     ##
     global MODEL_ALIASES
     ## Function calling specifics
-    functions = [function_call_signature(return_type)]
-    function_call = Dict(:name => only(functions)["name"])
+    tools = [Dict(:type => "function", :function => function_call_signature(return_type))]
+    ## force our function to be used
+    tool_choice = Dict(:type => "function",
+        :function => Dict(:name => only(tools)[:function]["name"]))
     ## Add the function call signature to the api_kwargs
-    api_kwargs = merge(api_kwargs, (; functions, function_call))
+    api_kwargs = merge(api_kwargs, (; tools, tool_choice))
     ## Find the unique ID for the model alias provided
     model_id = get(MODEL_ALIASES, model, model)
     conv_rendered = render(prompt_schema, prompt; conversation, kwargs...)
@@ -915,20 +982,26 @@ function aiextract(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_T
             conv_rendered;
             http_kwargs,
             api_kwargs...)
-        # "Safe" parsing of the response - it still fails if JSON is invalid
-        content = try
-            r.response[:choices][begin][:message][:function_call][:arguments] |>
-            x -> JSON3.read(x, return_type)
-        catch e
-            @warn "There was an error parsing the response: $e. Using the raw response instead."
-            r.response[:choices][begin][:message][:function_call][:arguments] |>
-            JSON3.read |> copy
+        ## Process one of more samples returned
+        msg = if length(r.response[:choices]) > 1
+            run_id = Int(rand(Int32)) # remember one run ID
+            ## extract all message
+            msgs = [response_to_message(prompt_schema, DataMessage, choice, r;
+                return_type, time, model_id, run_id, sample_id = i)
+                    for (i, choice) in enumerate(r.response[:choices])]
+            ## Order by log probability if available
+            ## bigger is better, keep it last
+            if all(x -> !isnothing(x.log_prob), msgs)
+                sort(msgs, by = x -> x.log_prob)
+            else
+                msgs
+            end
+        else
+            ## only 1 sample / 1 completion
+            choice = r.response[:choices][begin]
+            response_to_message(prompt_schema, DataMessage, choice, r;
+                return_type, time, model_id)
         end
-        msg = DataMessage(; content,
-            status = Int(r.status),
-            tokens = (r.response[:usage][:prompt_tokens],
-                r.response[:usage][:completion_tokens]),
-            elapsed = time)
         ## Reporting
         verbose && @info _report_stats(msg, model_id)
     else
@@ -947,7 +1020,7 @@ function aiextract(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_T
 end
 
 """
-aiscan([prompt_schema::AbstractOpenAISchema,] prompt::ALLOWED_PROMPT_TYPE; 
+    aiscan([prompt_schema::AbstractOpenAISchema,] prompt::ALLOWED_PROMPT_TYPE; 
     image_url::Union{Nothing, AbstractString, Vector{<:AbstractString}} = nothing,
     image_path::Union{Nothing, AbstractString, Vector{<:AbstractString}} = nothing,
     image_detail::AbstractString = "auto",
@@ -1066,12 +1139,26 @@ function aiscan(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_TYPE
             conv_rendered;
             http_kwargs,
             api_kwargs...)
-        msg = AIMessage(;
-            content = r.response[:choices][begin][:message][:content] |> strip,
-            status = Int(r.status),
-            tokens = (r.response[:usage][:prompt_tokens],
-                r.response[:usage][:completion_tokens]),
-            elapsed = time)
+        ## Process one of more samples returned
+        msg = if length(r.response[:choices]) > 1
+            run_id = Int(rand(Int32)) # remember one run ID
+            ## extract all message
+            msgs = [response_to_message(prompt_schema, AIMessage, choice, r;
+                time, model_id, run_id, sample_id = i)
+                    for (i, choice) in enumerate(r.response[:choices])]
+            ## Order by log probability if available
+            ## bigger is better, keep it last
+            if all(x -> !isnothing(x.log_prob), msgs)
+                sort(msgs, by = x -> x.log_prob)
+            else
+                msgs
+            end
+        else
+            ## only 1 sample / 1 completion
+            choice = r.response[:choices][begin]
+            response_to_message(prompt_schema, AIMessage, choice, r;
+                time, model_id)
+        end
         ## Reporting
         verbose && @info _report_stats(msg, model_id)
     else

--- a/src/llm_shared.jl
+++ b/src/llm_shared.jl
@@ -63,18 +63,6 @@ function render(schema::NoSchema,
     return conversation
 end
 
-"Utility to facilitate unwrapping of HTTP response to a message type `MSG` provided"
-function response_to_message(schema::AbstractPromptSchema,
-        MSG::Type{AbstractMessage},
-        choice,
-        resp;
-        model_id::AbstractString = "",
-        time::Float64 = 0.0,
-        run_id::Integer = rand(Int16),
-        sample_id::Union{Nothing, Integer} = nothing)
-    throw(ArgumentError("Response unwrapping not implemented for $(typeof(schema)) and $MSG"))
-end
-
 """
     finalize_outputs(prompt::ALLOWED_PROMPT_TYPE, conv_rendered::Any,
         msg::Union{Nothing, AbstractMessage, AbstractVector{<:AbstractMessage}};

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -61,18 +61,64 @@ function UserMessageWithImages(content::T, image_url::Vector{<:AbstractString},
     @assert length(not_allowed_kwargs)==0 "Error: Some placeholders are invalid, as they are reserved for `ai*` functions. Change: $(join(not_allowed_kwargs,","))"
     return UserMessageWithImages{T}(content, string.(image_url), variables, type)
 end
+
+"""
+    AIMessage
+
+A message type for AI-generated text-based responses. 
+Returned by `aigenerate`, `aiclassify`, and `aiscan` functions.
+    
+# Fields
+- `content::Union{AbstractString, Nothing}`: The content of the message.
+- `status::Union{Int, Nothing}`: The status of the message from the API.
+- `tokens::Tuple{Int, Int}`: The number of tokens used (prompt,completion).
+- `elapsed::Float64`: The time taken to generate the response in seconds.
+- `cost::Union{Nothing, Float64}`: The cost of the API call (calculated with information from `MODEL_REGISTRY`).
+- `log_prob::Union{Nothing, Float64}`: The log probability of the response.
+- `finish_reason::Union{Nothing, String}`: The reason the response was finished.
+- `run_id::Union{Nothing, Int}`: The unique ID of the run.
+- `sample_id::Union{Nothing, Int}`: The unique ID of the sample (if multiple samples are generated, they will all have the same `run_id`).
+"""
 Base.@kwdef struct AIMessage{T <: Union{AbstractString, Nothing}} <: AbstractChatMessage
     content::T = nothing
     status::Union{Int, Nothing} = nothing
     tokens::Tuple{Int, Int} = (-1, -1)
     elapsed::Float64 = -1.0
+    cost::Union{Nothing, Float64} = nothing
+    log_prob::Union{Nothing, Float64} = nothing
+    finish_reason::Union{Nothing, String} = nothing
+    run_id::Union{Nothing, Int} = Int(rand(Int16))
+    sample_id::Union{Nothing, Int} = nothing
     _type::Symbol = :aimessage
 end
+
+"""
+    DataMessage
+
+A message type for AI-generated data-based responses, ie, different `content` than text. 
+Returned by `aiextract`, and `aiextract` functions.
+    
+# Fields
+- `content::Union{AbstractString, Nothing}`: The content of the message.
+- `status::Union{Int, Nothing}`: The status of the message from the API.
+- `tokens::Tuple{Int, Int}`: The number of tokens used (prompt,completion).
+- `elapsed::Float64`: The time taken to generate the response in seconds.
+- `cost::Union{Nothing, Float64}`: The cost of the API call (calculated with information from `MODEL_REGISTRY`).
+- `log_prob::Union{Nothing, Float64}`: The log probability of the response.
+- `finish_reason::Union{Nothing, String}`: The reason the response was finished.
+- `run_id::Union{Nothing, Int}`: The unique ID of the run.
+- `sample_id::Union{Nothing, Int}`: The unique ID of the sample (if multiple samples are generated, they will all have the same `run_id`).
+"""
 Base.@kwdef struct DataMessage{T <: Any} <: AbstractDataMessage
     content::T
     status::Union{Int, Nothing} = nothing
     tokens::Tuple{Int, Int} = (-1, -1)
     elapsed::Float64 = -1.0
+    cost::Union{Nothing, Float64} = nothing
+    log_prob::Union{Nothing, Float64} = nothing
+    finish_reason::Union{Nothing, String} = nothing
+    run_id::Union{Nothing, Int} = Int(rand(Int16))
+    sample_id::Union{Nothing, Int} = nothing
     _type::Symbol = :datamessage
 end
 
@@ -83,6 +129,7 @@ end
 isusermessage(m::AbstractMessage) = m isa UserMessage
 issystemmessage(m::AbstractMessage) = m isa SystemMessage
 isdatamessage(m::AbstractMessage) = m isa DataMessage
+isaimessage(m::AbstractMessage) = m isa AIMessage
 
 # equality check for testing, only equal if all fields are equal and type is the same
 Base.var"=="(m1::AbstractMessage, m2::AbstractMessage) = false

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -134,7 +134,8 @@ isaimessage(m::AbstractMessage) = m isa AIMessage
 # equality check for testing, only equal if all fields are equal and type is the same
 Base.var"=="(m1::AbstractMessage, m2::AbstractMessage) = false
 function Base.var"=="(m1::T, m2::T) where {T <: AbstractMessage}
-    all([getproperty(m1, f) == getproperty(m2, f) for f in fieldnames(T)])
+    ## except for run_id, that's random and not important for content comparison
+    all([getproperty(m1, f) == getproperty(m2, f) for f in fieldnames(T) if f != :run_id])
 end
 
 ## Vision Models -- Constructor and Conversion

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -8,7 +8,9 @@ load_templates!();
 # API Calls prep
 mock_response = Dict(:choices => [
         Dict(:message => Dict(:content => "Hello!",
-                :function_call => Dict(:arguments => JSON3.write(Dict(:x => 1)))),
+                :tool_calls => [
+                    Dict(:function => Dict(:arguments => JSON3.write(Dict(:x => 1)))),
+                ]),
             :finish_reason => "stop"),
     ],
     :usage => Dict(:total_tokens => 3, :prompt_tokens => 2, :completion_tokens => 1))

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -8,7 +8,8 @@ load_templates!();
 # API Calls prep
 mock_response = Dict(:choices => [
         Dict(:message => Dict(:content => "Hello!",
-            :function_call => Dict(:arguments => JSON3.write(Dict(:x => 1))))),
+                :function_call => Dict(:arguments => JSON3.write(Dict(:x => 1)))),
+            :finish_reason => "stop"),
     ],
     :usage => Dict(:total_tokens => 3, :prompt_tokens => 2, :completion_tokens => 1))
 schema = TestEchoOpenAISchema(; response = mock_response, status = 200)

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -389,7 +389,10 @@ registry = Dict{String, ModelSpec}("gpt-3.5-turbo" => ModelSpec("gpt-3.5-turbo",
         "Mistral AI's hosted model for embeddings."),
     "echo" => ModelSpec("echo",
         TestEchoOpenAISchema(;
-            response = Dict(:choices => [Dict(:message => Dict(:content => "Hello!"))],
+            response = Dict(:choices => [
+                    Dict(:message => Dict(:content => "Hello!"),
+                        :finish_reason => "stop"),
+                ],
                 :usage => Dict(:total_tokens => 3,
                     :prompt_tokens => 2,
                     :completion_tokens => 1)), status = 200),

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -306,9 +306,17 @@ function call_cost(msg, model::String)
     end
     return cost
 end
-## dispatch for array -> take last message
-function call_cost(msg::AbstractVector, model::String)
-    call_cost(last(msg), model)
+## dispatch for array -> take unique messages only (eg, for multiple samples we count only once)
+function call_cost(conv::AbstractVector, model::String)
+    sum_ = 0.0
+    visited_runs = Set{Int}()
+    for msg in conv
+        if isnothing(msg.run_id) || (msg.run_id ∉ visited_runs)
+            sum_ += call_cost(msg, model)
+            push!(visited_runs, msg.run_id)
+        end
+    end
+    return sum_
 end
 
 # helper to produce summary message of how many tokens were used and for how much

--- a/test/Experimental/RAGTools/evaluation.jl
+++ b/test/Experimental/RAGTools/evaluation.jl
@@ -87,7 +87,9 @@ end
 
         if content[:model] == "mock-gen"
             user_msg = last(content[:messages])
-            response = Dict(:choices => [Dict(:message => user_msg)],
+            response = Dict(:choices => [
+                    Dict(:message => user_msg, :finish_reason => "stop"),
+                ],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),
@@ -101,10 +103,11 @@ end
         elseif content[:model] == "mock-meta"
             user_msg = last(content[:messages])
             response = Dict(:choices => [
-                    Dict(:message => Dict(:function_call => Dict(:arguments => JSON3.write(MaybeMetadataItems([
-                        MetadataItem("yes", "category"),
-                    ]))))),
-                ],
+                    Dict(:finish_reason => "stop",
+                        :message => Dict(:tool_calls => [
+                            Dict(:function => Dict(:arguments => JSON3.write(MaybeMetadataItems([
+                                MetadataItem("yes", "category"),
+                            ]))))]))],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),
@@ -112,9 +115,10 @@ end
         elseif content[:model] == "mock-qa"
             user_msg = last(content[:messages])
             response = Dict(:choices => [
-                    Dict(:message => Dict(:function_call => Dict(:arguments => JSON3.write(QAItem("Question",
-                        "Answer"))))),
-                ],
+                    Dict(:finish_reason => "stop",
+                        :message => Dict(:tool_calls => [
+                            Dict(:function => Dict(:arguments => JSON3.write(QAItem("Question",
+                                "Answer"))))]))],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),
@@ -122,14 +126,14 @@ end
         elseif content[:model] == "mock-judge"
             user_msg = last(content[:messages])
             response = Dict(:choices => [
-                    Dict(:message => Dict(:function_call => Dict(:arguments => JSON3.write(JudgeAllScores(5,
-                        5,
-                        5,
-                        5,
-                        5,
-                        "Some reasons",
-                        5.0))))),
-                ],
+                    Dict(:message => Dict(:tool_calls => [
+                        Dict(:function => Dict(:arguments => JSON3.write(JudgeAllScores(5,
+                            5,
+                            5,
+                            5,
+                            5,
+                            "Some reasons",
+                            5.0))))]))],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),

--- a/test/Experimental/RAGTools/generation.jl
+++ b/test/Experimental/RAGTools/generation.jl
@@ -1,4 +1,6 @@
-using PromptingTools.Experimental.RAGTools: MaybeMetadataItems, MetadataItem, build_context
+using PromptingTools.Experimental.RAGTools: ChunkIndex,
+    CandidateChunks, build_context, airag
+using PromptingTools.Experimental.RAGTools: MaybeMetadataItems, MetadataItem
 
 @testset "build_context" begin
     index = ChunkIndex(;
@@ -29,7 +31,7 @@ end
 
 @testset "airag" begin
     # test with a mock server
-    PORT = rand(1000:2000)
+    PORT = rand(20000:30000)
     PT.register_model!(; name = "mock-emb", schema = PT.CustomOpenAISchema())
     PT.register_model!(; name = "mock-meta", schema = PT.CustomOpenAISchema())
     PT.register_model!(; name = "mock-gen", schema = PT.CustomOpenAISchema())
@@ -39,7 +41,9 @@ end
 
         if content[:model] == "mock-gen"
             user_msg = last(content[:messages])
-            response = Dict(:choices => [Dict(:message => user_msg)],
+            response = Dict(:choices => [
+                    Dict(:message => user_msg, :finish_reason => "stop"),
+                ],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),
@@ -53,10 +57,11 @@ end
         elseif content[:model] == "mock-meta"
             user_msg = last(content[:messages])
             response = Dict(:choices => [
-                    Dict(:message => Dict(:function_call => Dict(:arguments => JSON3.write(MaybeMetadataItems([
-                        MetadataItem("yes", "category"),
-                    ]))))),
-                ],
+                    Dict(:finish_reason => "stop",
+                        :message => Dict(:tool_calls => [
+                            Dict(:function => Dict(:arguments => JSON3.write(MaybeMetadataItems([
+                                MetadataItem("yes", "category"),
+                            ]))))]))],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),

--- a/test/Experimental/RAGTools/preparation.jl
+++ b/test/Experimental/RAGTools/preparation.jl
@@ -82,7 +82,9 @@ end
 
         if content[:model] == "mock-gen"
             user_msg = last(content[:messages])
-            response = Dict(:choices => [Dict(:message => user_msg)],
+            response = Dict(:choices => [
+                    Dict(:message => user_msg, :finish_reason => "stop"),
+                ],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),
@@ -96,10 +98,11 @@ end
         elseif content[:model] == "mock-meta"
             user_msg = last(content[:messages])
             response = Dict(:choices => [
-                    Dict(:message => Dict(:function_call => Dict(:arguments => JSON3.write(MaybeMetadataItems([
-                        MetadataItem("yes", "category"),
-                    ]))))),
-                ],
+                    Dict(:finish_reason => "stop",
+                        :message => Dict(:tool_calls => [
+                            Dict(:function => Dict(:arguments => JSON3.write(MaybeMetadataItems([
+                                MetadataItem("yes", "category"),
+                            ]))))]))],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),

--- a/test/llm_shared.jl
+++ b/test/llm_shared.jl
@@ -267,4 +267,32 @@ end
         conversation,
         return_all = true)
     @test output == expected_output
+
+    ## With multiple samples
+    conversation = [
+        SystemMessage("System message 1"),
+        UserMessage("User message {{name}}"),
+        AIMessage("AI message"),
+    ]
+    messages = [
+        UserMessage("User message {{name}}"),
+        AIMessage("AI message 2"),
+    ]
+    msg = AIMessage("AI message 3")
+    expected_output = [
+        SystemMessage("System message 1"),
+        UserMessage("User message {{name}}"),
+        AIMessage("AI message"),
+        UserMessage("User message John", [:name], :usermessage),
+        AIMessage("AI message 2"),
+        msg,
+        msg,
+    ]
+    output = finalize_outputs(messages,
+        [],
+        [msg, msg];
+        name = "John",
+        conversation,
+        return_all = true)
+    @test output == expected_output
 end

--- a/test/messages.jl
+++ b/test/messages.jl
@@ -1,7 +1,7 @@
 using PromptingTools: AIMessage, SystemMessage, MetadataMessage
 using PromptingTools: UserMessage, UserMessageWithImages, DataMessage
 using PromptingTools: _encode_local_image, attach_images_to_user_message
-using PromptingTools: isusermessage, issystemmessage, isdatamessage
+using PromptingTools: isusermessage, issystemmessage, isdatamessage, isaimessage
 
 @testset "Message constructors" begin
     # Creates an instance of MSG with the given content string.
@@ -29,8 +29,8 @@ using PromptingTools: isusermessage, issystemmessage, isdatamessage
     @test UserMessage(content) |> isusermessage
     @test SystemMessage(content) |> issystemmessage
     @test DataMessage(; content) |> isdatamessage
+    @test AIMessage(; content) |> isaimessage
 end
-
 @testset "UserMessageWithImages" begin
     content = "Hello, world!"
     image_path = joinpath(@__DIR__, "data", "julia.png")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -137,6 +137,11 @@ end
     @test cost == 0.0
     @test call_cost(msg, "gpt-3.5-turbo") ≈ 1000 * 0.5e-6 + 1.5e-6 * 2000
 
+    # Test vector - same message, count once
+    @test call_cost([msg, msg], "gpt-3.5-turbo") ≈ (1000 * 0.5e-6 + 1.5e-6 * 2000)
+    msg2 = AIMessage(; content = "", tokens = (1000, 2000))
+    @test call_cost([msg, msg2], "gpt-3.5-turbo") ≈ (1000 * 0.5e-6 + 1.5e-6 * 2000) * 2
+
     msg = DataMessage(; content = nothing, tokens = (1000, 1000))
     cost = call_cost(msg, "unknown_model")
     @test cost == 0.0

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -129,6 +129,9 @@ end
 end
 
 @testset "call_cost" begin
+    @test cost = call_cost(1000, 100, "unknown_model";
+        cost_of_token_prompt = 1,
+        cost_of_token_generation = 1) ≈ 1100
     msg = AIMessage(; content = "", tokens = (1000, 2000))
     cost = call_cost(msg, "unknown_model")
     @test cost == 0.0
@@ -138,11 +141,6 @@ end
     cost = call_cost(msg, "unknown_model")
     @test cost == 0.0
     @test call_cost(msg, "gpt-3.5-turbo") ≈ 1000 * 0.5e-6 + 1.5e-6 * 1000
-
-    @test call_cost(msg,
-        "gpt-3.5-turbo";
-        cost_of_token_prompt = 1,
-        cost_of_token_generation = 1) ≈ 1000 + 1000
 end
 
 @testset "report_stats" begin


### PR DESCRIPTION
- Initial support for multiple completions in one request for OpenAI-compatible API servers. Set via API kwarg `n=5` and it will request 5 completions in one request, saving the network communication time and paying the prompt tokens only once. It's useful for majority voting, diversity, or challenging agentic workflows.
- Added new fields to `AIMessage` and `DataMessage` types to simplify tracking in complex applications. Added fields: 
  - `cost` - the cost of the query (summary per call, so count only once if you requested multiple completions in one call)
  - `log_prob` - summary log probability of the generated sequence, set API kwarg `logprobs=true` to receive it
  - `run_id`  - ID of the AI API call
  - `sample_id` - ID of the sample in the batch if you requested multiple completions, otherwise `sample_id==nothing` (they will have the same `run_id`)
  - `finish_reason` - the reason why the AI stopped generating the sequence (eg, "stop", "length") to provide more visibility for the user
