### PR TITLE
Improve create_template functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Fixed
+
+## [0.14.0]
+
+### Added
 - Added a new documentation section "How it works" to explain the inner workings of the package. It's a work in progress, but it should give you a good idea of what's happening under the hood.
 - Improved template loading, so if you load your custom templates once with `load_templates!("my/template/folder)`, it will remember your folder for all future re-loads.
-- Added convenience function `create_template` to create templates on the fly without having to deal with `PT.UserMessage` etc. See `?create_template` for more information.
+- Added convenience function `create_template` to create templates on the fly without having to deal with `PT.UserMessage` etc. If you specify the keyword argument `load_as = "MyName"`, the template will be immediately loaded to the template registry. See `?create_template` for more information and examples.
 
 ### Fixed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.14.0-DEV"
+version = "0.14.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/how_it_works.md
+++ b/docs/src/how_it_works.md
@@ -76,6 +76,8 @@ When you provide a Symbol (eg, `:AssistantAsk`) to ai* functions, thanks to the 
 
 You can discover all available templates with `aitemplates("some keyword")` or just see the details of some template `aitemplates(:AssistantAsk)`.
 
+Note: There is a new way to create and register templates in one go with `create_template(;user=<user prompt>, system=<system prompt>, load_as=<template name>)` (it skips the serialization step where a template previously must have been saved somewhere on the disk). See FAQ for more details or directly `?create_template`.
+
 ## ai* Functions
 
 The above steps are implemented in the `ai*` functions, eg, `aigenerate`, `aiembed`, `aiextract`, etc. They all have the same basic structure: 

--- a/test/templates.jl
+++ b/test/templates.jl
@@ -66,6 +66,15 @@ end
     @test tpl[2].content == "Say hi to {{chef}}"
     @test tpl[2].variables == [:chef]
     @test tpl[2] isa UserMessage
+
+    # use save_as
+    tpl = create_template(
+        "You must speak like a pirate", "Say hi to {{name}}"; load_as = :PirateGreetingX)
+    @test haskey(PT.TEMPLATE_STORE, :PirateGreetingX)
+    @test length(filter(x -> x.name == :PirateGreetingX, PT.TEMPLATE_METADATA)) == 1
+    ## clean up
+    delete!(PT.TEMPLATE_STORE, :PirateGreetingX)
+    filter!(x -> x.name != :PirateGreetingX, PT.TEMPLATE_METADATA)
 end
 
 @testset "Templates - Echo aigenerate call" begin


### PR DESCRIPTION
- Added convenience function `create_template` to create templates on the fly without having to deal with `PT.UserMessage` etc. If you specify the keyword argument `load_as = "MyName"`, the template will be immediately loaded to the template registry. See `?create_template` for more information and examples.
