### PR TITLE
Add support annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added pretty-printing via `PT.pprint` that does NOT depend on Markdown and splits text to adjust to the width of the output terminal.
+- Added support annotations for RAGTools (see `?RAGTools.Experimental.annotate_support` for more information) to highlight which parts of the generated answer come from the provided context versus the model's knowledge base. It's useful for transparency and debugging, especially in the context of AI-generated content. You can experience it if you run the output of `airag` through pretty printing (`PT.pprint`).
 
 ### Fixed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.15.0"
+version = "0.16.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Optional keyword arguments in `ai*` tend to be:
 - `api_kwargs::NamedTuple` - Specific parameters for the model, eg, `temperature=0.0` to be NOT creative (and have more similar output in each run)
 - `http_kwargs::NamedTuple` - Parameters for the HTTP.jl package, eg, `readtimeout = 120` to time out in 120 seconds if no response was received.
 
+**Experimental: AgentTools**
 
 In addition to the above list of `ai*` functions, you can also use the **"lazy" counterparts** of these functions from the experimental AgentTools module.
 ```julia
@@ -162,6 +163,15 @@ It uses exactly the same arguments and keyword arguments as `aigenerate` (see `?
 "lazy" refers to the fact that it does NOT generate any output when instantiated (only when `run!` is called). 
 
 Or said differently, the `AICall` struct and all its flavors (`AIGenerate`, ...) are designed to facilitate a deferred execution model (lazy evaluation) for AI functions that interact with a Language Learning Model (LLM). It stores the necessary information for an AI call and executes the underlying AI function only when supplied with a `UserMessage` or when the `run!` method is applied. This allows us to remember user inputs and trigger the LLM call repeatedly if needed, which enables automatic fixing (see `?airetry!`).
+
+**Experimental: RAGTools**
+
+Lastly, we provide a set of tools to build RAG applications (Retrieve, Answer, Generate). 
+
+It can be as simple as two calls: `build_index` and `airag` (Retrieve, Answer, Generate). 
+
+If you then use pretty-printing with `PromptingTools.pprint`, we highlight the generated text vs text likely sourced from the context and we score how strongly is the generated answer supported by the context.
+In addition, we annotate each generated chunk with a reference to which source document it likely came from (including the confidence score between 0 and 1).
 
 ### Seamless Integration Into Your Workflow
 Google search is great, but it's a context switch. You often have to open a few pages and read through the discussion to find the answer you need. Same with the ChatGPT website.

--- a/docs/src/examples/readme_examples.md
+++ b/docs/src/examples/readme_examples.md
@@ -28,6 +28,8 @@ Optional keyword arguments in `ai*` tend to be:
 - `api_kwargs::NamedTuple` - Specific parameters for the model, eg, `temperature=0.0` to be NOT creative (and have more similar output in each run)
 - `http_kwargs::NamedTuple` - Parameters for the HTTP.jl package, eg, `readtimeout = 120` to time out in 120 seconds if no response was received.
 
+**Experimental: AgentTools**
+
 In addition to the above list of `ai*` functions, you can also use the **"lazy" counterparts** of these functions from the experimental AgentTools module.
 ```julia
 using PromptingTools.Experimental.AgentTools
@@ -39,6 +41,15 @@ It uses exactly the same arguments and keyword arguments as `aigenerate` (see `?
 "lazy" refers to the fact that it does NOT generate any output when instantiated (only when `run!` is called). 
 
 Or said differently, the `AICall` struct and all its flavors (`AIGenerate`, ...) are designed to facilitate a deferred execution model (lazy evaluation) for AI functions that interact with a Language Learning Model (LLM). It stores the necessary information for an AI call and executes the underlying AI function only when supplied with a `UserMessage` or when the `run!` method is applied. This allows us to remember user inputs and trigger the LLM call repeatedly if needed, which enables automatic fixing (see `?airetry!`).
+
+**Experimental: RAGTools**
+
+Lastly, we provide a set of tools to build RAG applications (Retrieve, Answer, Generate). 
+
+It can be as simple as two calls: `build_index` and `airag` (Retrieve, Answer, Generate). 
+
+If you then use pretty-printing with `PromptingTools.pprint`, we highlight the generated text vs text likely sourced from the context and we score how strongly is the generated answer supported by the context.
+In addition, we annotate each generated chunk with a reference to which source document it likely came from (including the confidence score between 0 and 1).
 
 
 ## Seamless Integration Into Your Workflow

--- a/examples/building_RAG.jl
+++ b/examples/building_RAG.jl
@@ -22,7 +22,7 @@ const RT = PromptingTools.Experimental.RAGTools
 
 files = [
     joinpath("examples", "data", "database_style_joins.txt"),
-    joinpath("examples", "data", "what_is_dataframes.txt"),
+    joinpath("examples", "data", "what_is_dataframes.txt")
 ]
 ## Build an index of chunks, embed them, and create a lookup index of metadata/tags for each chunk
 index = build_index(files; extract_metadata = false)
@@ -42,7 +42,7 @@ answer = airag(index; question = "I like dplyr, what is the equivalent in Julia?
 #   - [OPTIONAL] extracts any potential tags/filters from the question and applies them to filter down the potential candidates (use `extract_metadata=true` in `build_index`, you can also provide some filters explicitly via `tag_filter`)
 #   - [OPTIONAL] re-ranks the candidate chunks (define and provide your own `rerank_strategy`, eg Cohere ReRank API)
 #   - build a context from the closest chunks (use `chunks_window_margin` to tweak if we include preceding and succeeding chunks as well, see `?build_context` for more details)
-# - generate an answer from the closest chunks (use `return_context=true` to see under the hood and debug your application)
+# - generate an answer from the closest chunks (use `return_details=true` to see under the hood and debug your application)
 
 # You should save the index for later to avoid re-embedding / re-extracting the document chunks!
 serialize("examples/index.jls", index)

--- a/src/Experimental/RAGTools/RAGTools.jl
+++ b/src/Experimental/RAGTools/RAGTools.jl
@@ -16,6 +16,8 @@ using AbstractTrees
 using AbstractTrees: PreOrderDFS
 const PT = PromptingTools
 
+## export trigrams, trigrams_hashed, text_to_trigrams, text_to_trigrams_hashed
+## export STOPWORDS, tokenize, split_into_code_and_sentences
 include("utils.jl")
 
 # eg, cohere_api

--- a/src/Experimental/RAGTools/RAGTools.jl
+++ b/src/Experimental/RAGTools/RAGTools.jl
@@ -10,13 +10,18 @@ This module is experimental and may change at any time. It is intended to be mov
 module RAGTools
 
 using PromptingTools
+using PromptingTools: pprint
 using HTTP, JSON3
+using AbstractTrees
+using AbstractTrees: PreOrderDFS
 const PT = PromptingTools
 
 include("utils.jl")
 
 # eg, cohere_api
 include("api_services.jl")
+
+include("rag_interface.jl")
 
 export ChunkIndex, CandidateChunks # MultiIndex
 include("types.jl")
@@ -29,6 +34,9 @@ include("retrieval.jl")
 
 export airag, build_context
 include("generation.jl")
+
+export annotate_support
+include("annotation.jl")
 
 export build_qa_evals, run_qa_evals
 include("evaluation.jl")

--- a/src/Experimental/RAGTools/annotation.jl
+++ b/src/Experimental/RAGTools/annotation.jl
@@ -15,13 +15,13 @@ end
 # Passthrough by default
 function align_node_styles!(
         annotater::AbstractAnnotater, nodes::AbstractVector{<:AbstractAnnotatedNode}; kwargs...)
-    node
+    nodes
 end
 
 # Passthrough by default
 function add_node_metadata!(annotater::AbstractAnnotater,
         root::AbstractAnnotatedNode; kwargs...)
-    node
+    root
 end
 
 """
@@ -93,8 +93,9 @@ AbstractTrees.parent(n::AbstractAnnotatedNode) = n.parent
 ## AbstractTrees.nodevalue(n::SampleNode) = n.data
 function Base.show(io::IO, node::AbstractAnnotatedNode;
         annotater::Union{Nothing, AbstractAnnotater} = nothing)
+    score_str = isnothing(node.score) ? "-" : round(node.score; digits = 2)
     print(io,
-        "$(nameof(typeof(node)))(group id: $(node.group_id), length: $(length(node.content)), score: $(round(node.score; digits=2))")
+        "$(nameof(typeof(node)))(group id: $(node.group_id), length: $(length(node.content)), score: $(score_str)")
 end
 
 """

--- a/src/Experimental/RAGTools/annotation.jl
+++ b/src/Experimental/RAGTools/annotation.jl
@@ -1,0 +1,426 @@
+
+# # Interface
+
+function annotate_support(
+        annotater::AbstractAnnotater, answer::AbstractString, context::AbstractVector)
+    throw(ArgumentError("Not implemented for type $(typeof(annotater))"))
+end
+
+# Passthrough by default
+function set_node_style!(
+        annotater::AbstractAnnotater, node::AbstractAnnotatedNode; kwargs...)
+    node
+end
+
+# Passthrough by default
+function align_node_styles!(
+        annotater::AbstractAnnotater, nodes::AbstractVector{<:AbstractAnnotatedNode}; kwargs...)
+    node
+end
+
+# Passthrough by default
+function add_node_metadata!(annotater::AbstractAnnotater,
+        root::AbstractAnnotatedNode; kwargs...)
+    node
+end
+
+"""
+    Styler
+
+Defines styling keywords for `printstyled` for each `AbstractAnnotatedNode`
+"""
+@kwdef mutable struct Styler <: AbstractAnnotationStyler
+    color::Symbol = :nothing
+    bold::Bool = false
+    underline::Bool = false
+    italic::Bool = false
+end
+
+"""
+    AnnotatedNode{T}  <: AbstractAnnotatedNode
+
+A node to add annotations to the generated answer in `airag`
+
+Annotations can be: sources, scores, whether its supported or not by the context, etc.
+
+# Fields
+- `id::UInt16`: Unique identifier for the node
+- `parent::Union{SampleNode, Nothing}`: Parent node that current node was built on
+- `children::Vector{SampleNode}`: Children nodes
+- `wins::Int`: Number of successful outcomes
+- `visits::Int`: Number of condition checks done (eg, losses are `checks - wins`)
+- `data::T`: eg, the conversation or some parameter to be optimized
+- `feedback::String`: Feedback from the evaluation, always a string! Defaults to empty string.
+- `success::Union{Nothing, Bool}`: Success of the generation and subsequent evaluations, proxy for whether it should be further evaluated. Defaults to nothing.
+"""
+@kwdef mutable struct AnnotatedNode{T} <: AbstractAnnotatedNode
+    group_id::Int = 0
+    parent::Union{AnnotatedNode, Nothing} = nothing
+    children::Vector{AnnotatedNode} = AnnotatedNode[]
+    score::Union{Nothing, Float64} = nothing
+    hits::Int = 0
+    content::T = SubString{String}("")
+    sources::Vector{Int} = Int[]
+    style::Styler = Styler()
+end
+Base.IteratorEltype(::Type{<:TreeIterator{AbstractAnnotatedNode}}) = Base.HasEltype()
+function Base.eltype(::Type{<:TreeIterator{T}}) where {T <: AbstractAnnotatedNode}
+    T
+end
+function AbstractTrees.childtype(::Type{T}) where {T <: AbstractAnnotatedNode}
+    T
+end
+function AbstractTrees.nodevalue(n::AbstractAnnotatedNode)
+    !isempty(n.children) ? "Group: $(n.group_id)" :
+    "$(n.content)($(isnothing(n.score) ? nothing : round(n.score;digits=2)))"
+end
+
+function AbstractTrees.children(node::AbstractAnnotatedNode)
+    return node.children
+end
+AbstractTrees.parent(n::AbstractAnnotatedNode) = n.parent
+## AbstractTrees.nodevalue(n::SampleNode) = n.data
+function Base.show(io::IO, node::AbstractAnnotatedNode;
+        annotater::Union{Nothing, AbstractAnnotater} = nothing)
+    ## score_str = isnothing(scoring) ? "" : ", score: $(round(score(node, scoring),digits=2))"
+    ## length_str = node.data isa AbstractVector ? ", length: $(length(node.data))" : ""
+    print(io,
+        "$(nameof(typeof(node)))(id: $(node.group_id), length: $(length(node.content)), score: $(node.score))")
+end
+
+"""
+    pprint(io::IO, node::AbstractAnnotatedNode)
+
+Pretty print the `node` to the `io` stream, including all its children
+"""
+function PromptingTools.pprint(io::IO, node::AbstractAnnotatedNode)
+    for node in AbstractTrees.PreOrderDFS(node)
+        ## print out text only for leaf nodes (ie, with no children)
+        if isempty(node.children)
+            printstyled(io, node.content; node.style.bold, node.style.color,
+                node.style.underline, node.style.italic)
+        end
+    end
+    return nothing
+end
+
+PromptingTools.pprint(node::AbstractAnnotatedNode) = pprint(stdout, node)
+
+#### TEXT UTILITIES
+function tokenize(input::Union{String, SubString{String}})
+    pattern = r"(\s+|=>|\(;|,|\.|\(|\)|\{|\}|\[|\]|;|:|\+|-|\*|/|<|>|=|&|\||!|@|#|\$|%|\^|~|`|\"|'|\w+)"
+    SubString{String}[m.match for m in eachmatch(pattern, input)]
+end
+
+function trigrams(input_string::AbstractString)
+    trigrams = SubString{String}[]
+    # Ensure the input string length is at least 3 to form a trigram
+    if length(input_string) >= 3
+        for i in 1:(length(input_string) - 2)
+            push!(trigrams, @views input_string[i:(i + 2)])
+        end
+    end
+    return trigrams
+end
+function trigrams_hashed(input_string::AbstractString)
+    trigrams = Set{UInt64}()
+    # Ensure the input string length is at least 3 to form a trigram
+    if length(input_string) >= 3
+        for i in 1:(length(input_string) - 2)
+            push!(trigrams, hash(@views input_string[i:(i + 2)]))
+        end
+    else
+        push!(trigrams, hash(input_string))
+    end
+    return trigrams
+end
+
+"Add boundaries to the token to improve the matched context (ie, separate partial matches from exact match)"
+function token_with_boundaries(
+        prev_token::Union{Nothing, AbstractString}, curr_token::AbstractString,
+        next_token::Union{Nothing, AbstractString})
+    ##
+    len1 = isnothing(prev_token) ? 0 : length(prev_token)
+    len2 = length(curr_token)
+    len3 = isnothing(next_token) ? 0 : length(next_token)
+
+    ## concat only if single token boundaries!
+    token = if len2 == 1
+        curr_token
+    elseif len1 == 1 && len3 == 1
+        prev_token * curr_token * next_token
+    elseif len1 == 0 && len3 == 1
+        ## no prev_token, but next_token
+        curr_token * next_token
+    elseif len3 == 1
+        curr_token * next_token
+    elseif len1 == 1
+        ## convert both len3=0 and len3>1
+        prev_token * curr_token
+    else
+        curr_token
+    end
+end
+
+function text_to_trigrams(input::Union{String, SubString{String}})
+    tokens = tokenize(input)
+    length_toks = length(tokens)
+    trig = SubString{String}[]
+    prev_token = nothing
+    for i in eachindex(tokens)
+        next_tok = i == length_toks ? nothing : tokens[i + 1]
+        curr_tok = tokens[i]
+        ## if too short, just add the token directly
+        if length(curr_tok) == 1
+            push!(trig, curr_tok)
+        else
+            full_tok = token_with_boundaries(prev_token, curr_tok, next_tok)
+            append!(trig, trigrams(full_tok))
+        end
+        prev_token = curr_tok
+    end
+    return trig
+end
+function text_to_trigrams_hashed(input::AbstractString)
+    tokens = tokenize(input)
+    length_toks = length(tokens)
+    trig = Set{UInt64}()
+    prev_token = nothing
+    for i in eachindex(tokens)
+        next_tok = i == length_toks ? nothing : tokens[i + 1]
+        curr_tok = tokens[i]
+        ## if too short, just add the token directly
+        if length(curr_tok) == 1
+            push!(trig, hash(curr_tok))
+        else
+            full_tok = token_with_boundaries(prev_token, curr_tok, next_tok)
+            union!(trig, trigrams_hashed(full_tok))
+        end
+        prev_token = curr_tok
+    end
+    return trig
+end
+
+function split_sentences(input::Union{String, SubString{String}})
+    # Pattern to match code blocks in triple backticks, inline code in backticks, and sentences in normal text
+    # This regex captures code blocks, inline code, and sentences, retaining their delimiters
+    pattern = r"(\n|\t|```[\s\S]+?```|^\s*[*+-]\s+|^\s*\d+\.\s+|[^.!?]+[.!?]|[\s\S]+)"ms
+    # TODO: single code line? `.+?`
+
+    # Initialize an empty array to store the split sentences
+    sentences = SubString{String}[]
+    group_ids = Int[]
+
+    # Process each match to handle code blocks and normal sentences differently
+    for (i, m) in enumerate(eachmatch(pattern, input))
+        sentence = m.match
+        # Check if the match is a code block with triple backticks
+        if startswith(sentence, "```") && endswith(sentence, "```")
+            # Split code block by newline, retaining the backticks
+            block_lines = split(sentence, "\n", keepempty = false)
+            append!(sentences, block_lines)
+            # all the lines of the chode block are the same group to have one source annotation
+            append!(group_ids, fill(i, length(block_lines)))
+        else
+            # For inline code and normal sentences, add them directly to the sentences array
+            push!(sentences, sentence)
+            push!(group_ids, i)
+        end
+    end
+
+    return sentences, group_ids
+end
+
+### ANNOTATION METHODS -- TrigramAnnotater
+
+"""
+    TrigramAnnotater
+
+Annotation method where we score answer versus each context based on word-level trigrams that match.
+
+It's very simple method (and it can loose some semantic meaning in longer sequences like negative), but it works reasonably well for both text and code.
+"""
+struct TrigramAnnotater <: AbstractAnnotater end
+
+"""
+    set_node_style!(annotater::TrigramAnnotater, node::AnnotatedNode; low_threshold::Float64=0.5, high_threshold::Float64=1.0,
+    high_styler::Styler=Styler(color=:green, bold=false), low_styler::Styler=Styler(color=:red, bold=false), bold_multihits::Bool=true)
+
+Sets style of `node` based on the provided rules
+"""
+function set_node_style!(annotater::TrigramAnnotater, node::AnnotatedNode;
+        low_threshold::Float64 = 0.0, medium_threshold::Float64 = 0.5, high_threshold::Float64 = 1.0,
+        low_styler::Styler = Styler(color = :magenta, bold = false),
+        medium_styler::Styler = Styler(color = :yellow, bold = false),
+        high_styler::Styler = Styler(color = :green, bold = false),
+        bold_multihits::Bool = true)
+    node.style = if isnothing(node.score)
+        ## skip for now
+        Styler()
+    elseif node.score >= high_threshold
+        high_styler
+    elseif node.score >= medium_threshold
+        medium_styler
+    elseif node.score >= low_threshold
+        low_styler
+    end
+    if node.hits > 1 && bold_multihits
+        node.style.bold = true
+    end
+    return node
+end
+
+"""
+    align_node_styles!(annotater::TrigramAnnotater, nodes::AbstractVector{<:AnnotatedNode}; kwargs...)
+
+Aligns the styles of the nodes based on the surrounding nodes ("fill-in-the-middle"). 
+
+If the node has no score, but the surrounding nodes have the same style, the node will inherit the style of the surrounding nodes.
+"""
+function align_node_styles!(
+        annotater::TrigramAnnotater, nodes::AbstractVector{<:AnnotatedNode}; kwargs...)
+    children_length = length(nodes)
+    for ci in eachindex(nodes)
+        if ci == 1 || ci == children_length
+            continue
+        else
+            prev, child, next = nodes[ci - 1], nodes[ci], nodes[ci + 1]
+            ## missing style and surrounding styles are the same
+            if isnothing(child.score) && prev.style == next.style
+                child.style = prev.style
+            end
+        end
+    end
+    return nodes
+end
+
+"Find if the `parent_node.content` is supported by the provided `context_trigrams`"
+function trigram_support!(parent_node::AnnotatedNode,
+        context_trigrams::AbstractVector; min_score::Float64 = 0.5,
+        styler_kwargs...)
+    method = TrigramAnnotater()
+    context_scores = zeros(Float64, length(context_trigrams))
+    ## Iterate max-sim over all the tokens (find match via trigrams)
+    tokens = tokenize(parent_node.content)
+    length_toks = length(tokens)
+    prev_token = nothing
+    for i in eachindex(tokens)
+        next_tok = i == length_toks ? nothing : tokens[i + 1]
+        curr_tok = tokens[i]
+        node = AnnotatedNode(; content = curr_tok, parent_node.group_id,
+            score = nothing, sources = Int[], parent = parent_node)
+        push!(parent_node.children, node)
+        ## find the highest scoring source based on trigrams
+        for si in eachindex(context_trigrams)
+            ## if too short, skip scoring
+            length(curr_tok) == 1 && continue
+            ## load trigrams in the context source
+            src = context_trigrams[si]
+            ## Score the trigram
+            full_tok = token_with_boundaries(prev_token, curr_tok, next_tok)
+            trig = trigrams(full_tok)
+            ## count portion of trigrams that match
+            score = count(in(src), trig) / length(trig)
+            # Add up cumulative score for each separate context
+            context_scores[si] += score
+            # if 1.0, increment hits
+            if score == 1
+                node.hits += 1
+            end
+            # log the highest score and sources, always log if exact match
+            if isnothing(node.score) || score > node.score || score == 1
+                node.score = score
+            end
+            if score >= min_score
+                push!(node.sources, si)
+            end
+        end
+        ## Set styles
+        set_node_style!(method, node; styler_kwargs...)
+
+        ## Next iteration
+        prev_token = curr_tok
+    end
+    ## Fill-in-middle Styler, based on the previous token and next token
+    align_node_styles!(method, parent_node.children)
+
+    ## Evaluate best source
+    idx = argmax(context_scores)
+    max_score = context_scores[idx]
+    if max_score >= min_score ## unnecessary, it's a sum of scores, so it will be over 0
+        parent_node.score = max_score / length_toks # avg score
+        parent_node.sources = [idx]
+    end
+
+    return parent_node
+end
+
+function add_node_metadata!(annotater::TrigramAnnotater,
+        root::AnnotatedNode; add_sources::Bool = true, add_scores::Bool = true,
+        sources::Union{Nothing, AbstractVector{<:AbstractString}} = nothing)
+    # Ensure there are children to process
+    if isempty(root.children)
+        return
+    end
+
+    # Placeholder for new children array with metadata nodes
+    new_children = AnnotatedNode[]
+    current_group_id = root.children[1].group_id
+    best_source = root.children[1].sources[1]
+    best_score = isnothing(root.children[1].score) ? 0 :
+                 root.children[1].score * length(root.children[1].content)
+    for child in root.children
+        # Check if group_id has changed or it's the last child
+        if child.group_id != current_group_id
+            # Add a metadata node for the previous group
+            metadata_content = add_scores ?
+                               "[$best_source,$(round(best_score, digits=2))]" :
+                               "[$best_source]"
+            push!(new_children, AnnotatedNode(content = metadata_content))
+            # Reset tracking variables
+            current_group_id = child.group_id
+            best_source = child.sources[1]
+            best_score = isnothing(child.score) ? 0 : child.score * length(child.content)
+        else
+            # Update best source based on score * content length
+            current_score = isnothing(child.score) ? 0 : child.score * length(child.content)
+            if current_score > best_score
+                best_source = child.sources[1]
+                best_score = current_score
+            end
+        end
+        push!(new_children, child)
+    end
+    # Add metadata for the last group if necessary
+    if add_sources
+        metadata_content = add_scores ? "[$best_source,$(round(best_score, digits=2))]" :
+                           "[$best_source]"
+        push!(new_children, AnnotatedNode(content = metadata_content))
+    end
+
+    # Replace old children with new ones including metadata nodes
+    root.children = new_children
+
+    # TODO: Add the actual sources at the end if provided
+
+    return root
+end
+
+"Annotates the `answer` with the `context` and returns the annotated tree of nodes representing the `answer`"
+function annotate_support(annotater::TrigramAnnotater, answer::AbstractString,
+        context::AbstractVector; min_score::Float64 = 0.5, add_sources::Bool = true,
+        add_scores::Bool = true, kwargs...)
+    # TODO: add RAG sources - inline and at the end of the context
+    sentences, group_ids = split_sentences(answer)
+    context_trigrams = text_to_trigrams.(context)
+    root = AnnotatedNode()
+    for i in eachindex(sentences, group_ids)
+        node = AnnotatedNode(;
+            content = sentences[i], group_id = group_ids[i], parent = root)
+        push!(root.children, node)
+        trigram_support!(node, context_trigrams; min_score, kwargs...)
+    end
+    ## add_sources/scores if requested
+    ## add_node_metadata!(annotater, root; add_sources, add_scores)
+    return root
+end

--- a/src/Experimental/RAGTools/annotation.jl
+++ b/src/Experimental/RAGTools/annotation.jl
@@ -109,8 +109,15 @@ function PromptingTools.pprint(
     for node in AbstractTrees.PreOrderDFS(node)
         ## print out text only for leaf nodes (ie, with no children)
         if isempty(node.children)
-            printstyled(io, node.content; node.style.bold, node.style.color,
-                node.style.underline, node.style.italic)
+            @static if VERSION ≥ v"1.10"
+                printstyled(io, node.content; node.style.bold, node.style.color,
+                    node.style.underline, node.style.italic)
+            else
+                ## Implies VERSION ≥ v"1.9" (not supported below)
+                ## Remove italic keyword
+                printstyled(io, node.content; node.style.bold, node.style.color,
+                    node.style.underline)
+            end
         end
     end
     return nothing

--- a/src/Experimental/RAGTools/evaluation.jl
+++ b/src/Experimental/RAGTools/evaluation.jl
@@ -266,7 +266,7 @@ function run_qa_evals(index::AbstractChunkIndex, qa_items::AbstractVector{<:QAEv
     # Run evaluations in parallel
     results = asyncmap(qa_items) do qa_item
         # Generate an answer -- often you want the model_judge to be the highest quality possible, eg, "GPT-4 Turbo" (alias "gpt4t)
-        msg, ctx = airag(index; qa_item.question, return_context = true,
+        msg, ctx = airag(index; qa_item.question, return_details = true,
             verbose, api_kwargs, airag_kwargs...)
 
         # Evaluate the response

--- a/src/Experimental/RAGTools/evaluation.jl
+++ b/src/Experimental/RAGTools/evaluation.jl
@@ -143,15 +143,15 @@ function score_retrieval_rank(orig_context::AbstractString,
 end
 
 """
-    run_qa_evals(qa_item::QAEvalItem, ctx::RAGContext; verbose::Bool = true,
+    run_qa_evals(qa_item::QAEvalItem, ctx::RAGDetails; verbose::Bool = true,
                  parameters_dict::Dict{Symbol, <:Any}, judge_template::Symbol = :RAGJudgeAnswerFromContext,
                  model_judge::AbstractString, api_kwargs::NamedTuple = NamedTuple()) -> QAEvalResult
 
-Evaluates a single `QAEvalItem` using a RAG context (`RAGContext`) and returns a `QAEvalResult` structure. This function assesses the relevance and accuracy of the answers generated in a QA evaluation context.
+Evaluates a single `QAEvalItem` using RAG details (`RAGDetails`) and returns a `QAEvalResult` structure. This function assesses the relevance and accuracy of the answers generated in a QA evaluation context.
 
 # Arguments
 - `qa_item::QAEvalItem`: The QA evaluation item containing the question and its answer.
-- `ctx::RAGContext`: The context used for generating the QA pair, including the original context and the answers.
+- `ctx::RAGDetails`: The context used for generating the QA pair, including the original context and the answers.
   Comes from `airag(...; return_context=true)`
 - `verbose::Bool`: If `true`, enables verbose logging. Defaults to `true`.
 - `parameters_dict::Dict{Symbol, Any}`: Track any parameters used for later evaluations. Keys must be Symbols.
@@ -173,13 +173,13 @@ Evaluates a single `QAEvalItem` using a RAG context (`RAGContext`) and returns a
 Evaluating a QA pair using a specific context and model:
 ```julia
 qa_item = QAEvalItem(question="What is the capital of France?", answer="Paris", context="France is a country in Europe.")
-ctx = RAGContext(source="Wikipedia", context="France is a country in Europe.", answer="Paris")
+ctx = RAGDetails(source="Wikipedia", context="France is a country in Europe.", answer="Paris")
 parameters_dict = Dict("param1" => "value1", "param2" => "value2")
 
 eval_result = run_qa_evals(qa_item, ctx, parameters_dict=parameters_dict, model_judge="MyAIJudgeModel")
 ```
 """
-function run_qa_evals(qa_item::QAEvalItem, ctx::RAGContext;
+function run_qa_evals(qa_item::QAEvalItem, ctx::RAGDetails;
         verbose::Bool = true, parameters_dict::Dict{Symbol, <:Any} = Dict{Symbol, Any}(),
         judge_template::Symbol = :RAGJudgeAnswerFromContextShort,
         model_judge::AbstractString = PT.MODEL_CHAT,
@@ -187,7 +187,7 @@ function run_qa_evals(qa_item::QAEvalItem, ctx::RAGContext;
     retrieval_score = score_retrieval_hit(qa_item.context, ctx.context)
     retrieval_rank = score_retrieval_rank(qa_item.context, ctx.context)
 
-    # Note we could evaluate if RAGContext and QAEvalItem are at least using the same sources etc. 
+    # Note we could evaluate if RAGDetails and QAEvalItem are at least using the same sources etc. 
 
     answer_score = try
         msg = aiextract(judge_template; model = model_judge, verbose,

--- a/src/Experimental/RAGTools/generation.jl
+++ b/src/Experimental/RAGTools/generation.jl
@@ -101,7 +101,19 @@ msg = airag(index, :RAGAnswerFromContext; question)
 msg = airag(index; question)
 ```
 
-See also `build_index`, `build_context`, `CandidateChunks`, `find_closest`, `find_tags`, `rerank`
+To understand the details of the RAG process, use `return_details=true`
+```julia
+msg, details = airag(index; question, return_details = true)
+# details is a RAGDetails object with all the internal steps of the `airag` function
+```
+
+You can also pretty-print `details` to highlight generated text vs text that is supported by context.
+It also includes annotations of which context was used for each part of the response (where available).
+```julia
+PT.pprint(details)
+```
+
+See also `build_index`, `build_context`, `CandidateChunks`, `find_closest`, `find_tags`, `rerank`, `annotate_support`
 """
 function airag(index::AbstractChunkIndex, rag_template::Symbol = :RAGAnswerFromContext;
         question::AbstractString,

--- a/src/Experimental/RAGTools/generation.jl
+++ b/src/Experimental/RAGTools/generation.jl
@@ -81,7 +81,7 @@ The function selects relevant chunks from an `ChunkIndex`, optionally filters th
 
 # Returns
 - If `return_details` is `false`, returns the generated message (`msg`).
-- If `return_details` is `true`, returns a tuple of the generated message (`msg`) and the RAG context (`rag_context`).
+- If `return_details` is `true`, returns a tuple of the generated message (`msg`) and the `RAGDetails` for context (`rag_details`).
 
 # Notes
 - The function first finds the closest chunks to the question embedding, then optionally filters these based on tags. After that, it reranks the candidates and builds a context for the RAG model.
@@ -183,7 +183,7 @@ function airag(index::AbstractChunkIndex, rag_template::Symbol = :RAGAnswerFromC
         joined_kwargs...)
 
     if return_details # for evaluation
-        rag_context = RAGDetails(;
+        rag_details = RAGDetails(;
             question,
             rephrased_question = [question],
             answer = msg.content,
@@ -194,8 +194,15 @@ function airag(index::AbstractChunkIndex, rag_template::Symbol = :RAGAnswerFromC
             tag_candidates,
             filtered_candidates,
             reranked_candidates)
-        return msg, rag_context
+        return msg, rag_details
     else
         return msg
     end
+end
+
+# Special method to pretty-print the airag results
+function PT.pprint(io::IO, airag_result::Tuple{PT.AIMessage, AbstractRAGResult},
+        text_width::Int = displaysize(io)[2])
+    rag_details = airag_result[2]
+    pprint(io, rag_details; text_width)
 end

--- a/src/Experimental/RAGTools/rag_interface.jl
+++ b/src/Experimental/RAGTools/rag_interface.jl
@@ -1,0 +1,101 @@
+############################
+### THIS IS WORK IN PROGRESS
+############################
+
+# This is the outline of the current RAG interface.
+#
+### System Overview
+#
+# This system is designed for information retrieval and response generation, structured in three main phases:
+# - Preparation, when you create an instance of `AbstractIndex`
+# - Retrieval, when you surface the top most relevant chunks/items in the `index` 
+# - Generation, when you generate an answer based on the retrieved chunks
+#
+# The system is designed to be hackable and extensible at almost every entry point.
+# You just need to define the corresponding concrete type (struct XYZ <: AbstractXYZ end) and the corresponding method.
+# Then you pass the instance of this new type via kwargs, eg, `annotater=TrigramAnnotater()`
+#
+### RAG Diagram
+#
+# build_index
+#   signature: () -> AbstractChunkIndex
+#   flow: get_chunks -> get_embeddings -> get_tags
+# 
+# airag: 
+#   signature: () -> AIMessage or (AIMessage, RAGContext)
+#   flow: retrieve -> generate
+#
+# retrieve:
+#   signature: () -> RAGContext
+#   flow: rephrase -> aiembed -> find_closest -> find_exact -> rerank
+#
+# generate:
+#  signature: () -> AIMessage or (AIMessage, RAGContext)
+#  flow: format_context -> aigenerate -> refine   
+#
+### Deepdive
+#
+# Preparation Phase:
+# - Begins with `build_index`, which creates a user-defined index type from an abstract chunk index using specified models and function strategies.
+# - `get_chunks` then divides the indexed data into manageable pieces based on a chunking strategy.
+# - `get_embeddings` generates embeddings for each chunk using an embedding strategy to facilitate similarity searches.
+# - Finally, `get_metadata` extracts relevant metadata from each chunk using a metadata strategy, enabling metadata-based filtering.
+#
+# Generation/E2E Phase:
+# - Starts with `airag`, initiating the response generation process using a custom index to potentially alter the high-level structure.
+# - The `retrieve` step employs a retrieval strategy to fetch relevant data, which can be modified by a rephrase strategy for better query matching.
+# - `aiembed` generates embeddings for the rephrased query, which are used in `find_closest` to identify the most relevant chunks using a similarity strategy.
+# - Optional tag filtering (`aiextract + find_exact`) can be applied before candidates are re-ranked using a reranking strategy.
+# - `format_context` constructs the context for response generation based on a context strategy, leading to the `aigenerate` step that produces the final answer.
+# - The process concludes with `Refine`, applying a refine strategy for any final adjustments or re-evaluation.
+#
+
+### Types
+############################
+### NOT READY!!!
+############################
+
+#
+# Defines three key types for RAG: ChunkIndex, MultiIndex, and CandidateChunks
+# In addition, RAGContext is defined for debugging purposes
+
+# ## Preparation Stage
+
+abstract type AbstractDocumentIndex end
+abstract type AbstractMultiIndex <: AbstractDocumentIndex end
+abstract type AbstractChunkIndex <: AbstractDocumentIndex end
+
+abstract type AbstractCandidateChunks end
+
+abstract type AbstractRAGResult end
+
+# ## Retrieval stage
+abstract type AbstractRetrievalStrategies end
+
+# Main dispatch type for `rephrase`
+abstract type AbstractRephraserStrategy <: AbstractRetrievalStrategies end
+
+# Main dispatch type for `find_similar`
+abstract type AbstractSimilarityStrategy <: AbstractRetrievalStrategies end
+
+# Main dispatch type for `find_exact`
+abstract type AbstractExactnessStrategy <: AbstractRetrievalStrategies end
+
+# Main dispatch type for `rerank`
+abstract type AbstractRerankerStrategy <: AbstractRetrievalStrategies end
+
+# ## Generation stage
+abstract type AbstractGenerationStrategies end
+
+# Main dispatch type for: `format_context`
+abstract type AbstractContextFormater <: AbstractGenerationStrategies end
+
+# Main dispatch type for: `refine`
+abstract type AbstractRefiner <: AbstractGenerationStrategies end
+
+# ## Exploration/Display stage
+
+abstract type AbstractAnnotater end
+
+abstract type AbstractAnnotatedNode end
+abstract type AbstractAnnotationStyler end

--- a/src/Experimental/RAGTools/rag_interface.jl
+++ b/src/Experimental/RAGTools/rag_interface.jl
@@ -22,12 +22,12 @@
 #   flow: get_chunks -> get_embeddings -> get_tags
 # 
 # airag: 
-#   signature: () -> AIMessage or (AIMessage, RAGContext)
+#   signature: () -> AIMessage or (AIMessage, RAGDetails)
 #   flow: retrieve -> generate
 #
 # retrieve:
 #   signature: () -> RAGContext
-#   flow: rephrase -> aiembed -> find_closest -> find_exact -> rerank
+#   flow: rephrase -> aiembed -> find_closest -> find_tags -> rerank
 #
 # generate:
 #  signature: () -> AIMessage or (AIMessage, RAGContext)
@@ -67,34 +67,37 @@ abstract type AbstractChunkIndex <: AbstractDocumentIndex end
 
 abstract type AbstractCandidateChunks end
 
+# supertype for RAGDetails
 abstract type AbstractRAGResult end
 
 # ## Retrieval stage
-abstract type AbstractRetrievalStrategies end
+# Main dispatch type for `retrieve`
+abstract type AbstractRetrievalMethod end
 
 # Main dispatch type for `rephrase`
-abstract type AbstractRephraserStrategy <: AbstractRetrievalStrategies end
+abstract type AbstractRephraser <: AbstractRetrievalMethod end
 
-# Main dispatch type for `find_similar`
-abstract type AbstractSimilarityStrategy <: AbstractRetrievalStrategies end
+# Main dispatch type for `find_closest`
+abstract type AbstractSimilaritySearch <: AbstractRetrievalMethod end
 
-# Main dispatch type for `find_exact`
-abstract type AbstractExactnessStrategy <: AbstractRetrievalStrategies end
+# Main dispatch type for `find_tags`
+abstract type AbstractTagMatch <: AbstractRetrievalMethod end
 
 # Main dispatch type for `rerank`
-abstract type AbstractRerankerStrategy <: AbstractRetrievalStrategies end
+abstract type AbstractReranker <: AbstractRetrievalMethod end
 
 # ## Generation stage
-abstract type AbstractGenerationStrategies end
+abstract type AbstractGenerationMethod end
 
 # Main dispatch type for: `format_context`
-abstract type AbstractContextFormater <: AbstractGenerationStrategies end
+abstract type AbstractContextFormater <: AbstractGenerationMethod end
 
 # Main dispatch type for: `refine`
-abstract type AbstractRefiner <: AbstractGenerationStrategies end
+abstract type AbstractRefiner <: AbstractGenerationMethod end
 
 # ## Exploration/Display stage
 
+# Supertype for annotaters, dispatch for `annotate_support`
 abstract type AbstractAnnotater end
 
 abstract type AbstractAnnotatedNode end

--- a/src/Experimental/RAGTools/types.jl
+++ b/src/Experimental/RAGTools/types.jl
@@ -1,10 +1,4 @@
-### Types
-# Defines three key types for RAG: ChunkIndex, MultiIndex, and CandidateChunks
-# In addition, RAGContext is defined for debugging purposes
 
-abstract type AbstractDocumentIndex end
-abstract type AbstractMultiIndex <: AbstractDocumentIndex end
-abstract type AbstractChunkIndex <: AbstractDocumentIndex end
 # More advanced index would be: HybridChunkIndex
 
 # Stores document chunks and their embeddings
@@ -26,7 +20,7 @@ Main struct for storing document chunks and their embeddings. It also stores tag
     T1 <: AbstractString,
     T2 <: Union{Nothing, Matrix{<:Real}},
     T3 <: Union{Nothing, AbstractMatrix{<:Bool}},
-    T4 <: Union{Nothing, AbstractVector},
+    T4 <: Union{Nothing, AbstractVector}
 } <: AbstractChunkIndex
     id::Symbol = gensym("ChunkIndex")
     # underlying document chunks / snippets
@@ -96,7 +90,6 @@ function Base.var"=="(i1::MultiIndex, i2::MultiIndex)
     return true
 end
 
-abstract type AbstractCandidateChunks end
 @kwdef struct CandidateChunks{TP <: Union{Integer, AbstractCandidateChunks}, TD <: Real} <:
               AbstractCandidateChunks
     index_id::Symbol
@@ -191,13 +184,15 @@ function Base.getindex(mi::MultiIndex,
 end
 
 """
-    RAGContext
+    RAGDetails
 
 A struct for debugging RAG answers. It contains the question, answer, context, and the candidate chunks at each step of the RAG pipeline.
 """
-@kwdef struct RAGContext
+@kwdef mutable struct RAGDetails <: AbstractRAGResult
     question::AbstractString
+    rephrased_question::AbstractVector{<:AbstractString}
     answer::AbstractString
+    refined_answer::AbstractString
     context::Vector{<:AbstractString}
     sources::Vector{<:AbstractString}
     emb_candidates::CandidateChunks
@@ -208,6 +203,6 @@ end
 
 # Structured show method for easier reading (each kwarg on a new line)
 function Base.show(io::IO,
-        t::Union{AbstractDocumentIndex, AbstractCandidateChunks, RAGContext})
+        t::Union{AbstractDocumentIndex, AbstractCandidateChunks, AbstractRAGResult})
     dump(IOContext(io, :limit => true), t, maxdepth = 1)
 end

--- a/src/Experimental/RAGTools/utils.jl
+++ b/src/Experimental/RAGTools/utils.jl
@@ -1,15 +1,3 @@
-# STOPWORDS - used for annotation highlighting
-# Just a small list to
-const STOPWORDS = [
-    "a", "an", "the", "and", "is", "isn't", "are", "aren't", "be", "was", "wasn't", "been",
-    "will", "won't", "would", "wouldn't",
-    "have", "haven't", "has", "hasn't", "do", "don't", "does", "did", "to",
-    "from", "go", "goes", "went", "gone", "at",
-    "into", "on", "or", "but", "per", "so", "then", "than",
-    "what", "why", "who", "where", "whom", "which", "that", "with",
-    "its", "their"] |> x -> vcat(x, titlecase.(x))
-# "if","else","elseif", "in", "for", "let","for", 
-
 # Utility to check model suitability
 function _check_aiextract_capability(model::AbstractString)
     # Check that the provided model is known and that it is an OpenAI model (for the aiextract function to work)
@@ -32,4 +20,232 @@ function merge_labeled_matrices(mat1::AbstractMatrix{T1},
     aligned_mat2 = aligned_mat2 |> Base.Splat(hcat)
 
     return vcat(aligned_mat1, aligned_mat2), combined_vocab
+end
+
+### Text Utilities
+# STOPWORDS - used for annotation highlighting
+# Just a small list to get started
+const STOPWORDS = [
+    "a", "an", "the", "and", "is", "isn't", "are", "aren't", "be", "was", "wasn't", "been",
+    "will", "won't", "would", "wouldn't",
+    "have", "haven't", "has", "hasn't", "do", "don't", "does", "did", "to",
+    "from", "go", "goes", "went", "gone", "at",
+    "into", "on", "or", "but", "per", "so", "then", "than",
+    "what", "why", "who", "where", "whom", "which", "that", "with",
+    "its", "their"] |> x -> vcat(x, titlecase.(x))
+# Some stop words intentionally omitted as we want to track them for code:
+# "if","else","elseif", "in", "for", "let","for",  
+
+"""
+    tokenize(input::Union{String, SubString{String}})
+
+Tokenizes provided `input` by spaces, special characters or Julia symbols (eg, `=>`).
+
+Unlike other tokenizers, it aims to lossless - ie, keep both the separated text and the separators.
+"""
+function tokenize(input::Union{String, SubString{String}})
+    pattern = r"(\s+|=>|\(;|,|\.|\(|\)|\{|\}|\[|\]|;|:|\+|-|\*|/|<|>|=|&|\||!|@|#|\$|%|\^|~|`|\"|'|\w+)"
+    SubString{String}[m.match for m in eachmatch(pattern, input)]
+end
+
+"""
+    trigrams(input_string::AbstractString; add_word::AbstractString = "")
+
+Splits provided `input_string` into a vector of trigrams (combination of three consecutive characters found in the `input_string`).
+
+If `add_word` is provided, it is added to the resulting array. Useful to add the full word itself to the resulting array for exact match.
+"""
+function trigrams(input_string::AbstractString; add_word::AbstractString = "")
+    trigrams = SubString{String}[]
+    # Ensure the input string length is at least 3 to form a trigram
+    if length(input_string) >= 3
+        nunits = ncodeunits(input_string)
+        i = 1
+        while i <= nunits
+            j = nextind(input_string, i, 2)
+            if j <= nunits
+                push!(trigrams, @views input_string[i:j])
+                ## next starter
+                i = nextind(input_string, i)
+            else
+                break
+            end
+        end
+        ## else
+        ##     push!(trigrams, convert(SubString{String}, input_string))
+    end
+    !isempty(add_word) && push!(trigrams, convert(SubString{String}, add_word))
+    return trigrams
+end
+
+"""
+    trigrams_hashed(input_string::AbstractString; add_word::AbstractString = "")
+
+Splits provided `input_string` into a Set of hashed trigrams (combination of three consecutive characters found in the `input_string`).
+
+It is more efficient for lookups in large strings (eg, >100K characters).
+
+If `add_word` is provided, it is added to the resulting array to hash. Useful to add the full word itself to the resulting array for exact match.
+"""
+function trigrams_hashed(input_string::AbstractString; add_word::AbstractString = "")
+    trigrams = Set{UInt64}()
+    # Ensure the input string length is at least 3 to form a trigram
+    if length(input_string) >= 3
+        nunits = ncodeunits(input_string)
+        i = 1
+        while i <= nunits
+            j = nextind(input_string, i, 2)
+            if j <= nunits
+                push!(trigrams, hash(@views input_string[i:j]))
+                ## next starter
+                i = nextind(input_string, i)
+            else
+                break
+            end
+        end
+        ## else
+        ##     push!(trigrams, hash(input_string))
+    end
+    !isempty(add_word) && push!(trigrams, hash(add_word))
+    return trigrams
+end
+
+"""
+    token_with_boundaries(
+        prev_token::Union{Nothing, AbstractString}, curr_token::AbstractString,
+        next_token::Union{Nothing, AbstractString})
+
+Joins the three tokens together. Useful to add boundary tokens (like spaces vs brackets) to the `curr_token` to improve the matched context (ie, separate partial matches from exact match)
+"""
+function token_with_boundaries(
+        prev_token::Union{Nothing, AbstractString}, curr_token::AbstractString,
+        next_token::Union{Nothing, AbstractString})
+    ##
+    len1 = isnothing(prev_token) ? 0 : length(prev_token)
+    len2 = length(curr_token)
+    len3 = isnothing(next_token) ? 0 : length(next_token)
+
+    ## concat only if single token boundaries!
+    token = if len2 == 1
+        curr_token
+    elseif len1 == 1 && len3 == 1
+        prev_token * curr_token * next_token
+    elseif len1 == 0 && len3 == 1
+        ## no prev_token, but next_token
+        curr_token * next_token
+    elseif len3 == 1
+        curr_token * next_token
+    elseif len1 == 1
+        ## convert both len3=0 and len3>1
+        prev_token * curr_token
+    else
+        curr_token
+    end
+end
+
+function text_to_trigrams(input::Union{String, SubString{String}}; add_word::Bool = true)
+    tokens = tokenize(input)
+    length_toks = length(tokens)
+    trig = SubString{String}[]
+    prev_token = nothing
+    for i in eachindex(tokens)
+        next_tok = i == length_toks ? nothing : tokens[i + 1]
+        curr_tok = tokens[i]
+        ## if too short, skip the token
+        if length(curr_tok) > 1
+            ##     push!(trig, curr_tok)
+            ## else
+            full_tok = token_with_boundaries(prev_token, curr_tok, next_tok)
+            if add_word
+                append!(trig, trigrams(full_tok; add_word = curr_tok))
+            else
+                append!(trig, trigrams(full_tok))
+            end
+        end
+        prev_token = curr_tok
+    end
+    return trig
+end
+function text_to_trigrams_hashed(input::AbstractString; add_word::Bool = true)
+    tokens = tokenize(input)
+    length_toks = length(tokens)
+    trig = Set{UInt64}()
+    prev_token = nothing
+    for i in eachindex(tokens)
+        next_tok = i == length_toks ? nothing : tokens[i + 1]
+        curr_tok = tokens[i]
+        ## if too short, just skip the token
+        if length(curr_tok) > 1
+            ##     push!(trig, hash(curr_tok))
+            ## else
+            full_tok = token_with_boundaries(prev_token, curr_tok, next_tok)
+            if add_word
+                union!(trig, trigrams_hashed(full_tok; add_word = curr_tok))
+            else
+                union!(trig, trigrams_hashed(full_tok))
+            end
+        end
+        prev_token = curr_tok
+    end
+    return trig
+end
+
+"""
+    split_into_code_and_sentences(input::Union{String, SubString{String}})
+
+Splits text block into code or text and sub-splits into units.
+
+If code block, it splits by newline but keep the `group_id` the same (to have the same source)
+If text block, splits into sentences, bullets, etc., provides different `group_id` (to have different source)
+"""
+function split_into_code_and_sentences(input::Union{String, SubString{String}})
+    # Combining the patterns for code blocks, inline code, and sentences in one regex
+    # This pattern aims to match code blocks first, then inline code, and finally any text outside of code blocks as sentences or parts thereof.
+    pattern = r"(```[\s\S]+?```)|(`[^`]*?`)|([^`]+)"
+
+    ## Patterns for sentences: newline, tab, bullet, enumerate list, sentence, any left out characters
+    sentence_pattern = r"(\n|\t|^\s*[*+-]\s*|^\s*\d+\.\s+|[^\n\t*+-.!?]+|[\n\t*+-.!?])"ms
+
+    # Initialize an empty array to store the split sentences
+    sentences = SubString{String}[]
+    group_ids = Int[]
+
+    # Loop over the input string, searching for matches to the pattern
+    i = 1
+    for m in eachmatch(pattern, input)
+        ## number of sub-parts
+        j = 1
+        # Extract the full match, including any delimiters
+        match_block = m.match
+        # Check if the match is a code block with triple backticks
+        if startswith(match_block, "```")
+            # Split code block by newline, retaining the backticks
+            block_lines = split(match_block, "\n", keepempty = false)
+            for (cnt, block) in enumerate(block_lines)
+                push!(sentences, block)
+                # all the lines of the chode block are the same group to have one source annotation
+                push!(group_ids, i)
+                if cnt < length(block_lines)
+                    ## return newlines
+                    push!(sentences, "\n")
+                    push!(group_ids, i)
+                end
+            end
+        elseif startswith(match_block, "`")
+            push!(sentences, match_block)
+            push!(group_ids, i)
+        else
+            ## Split text further
+            j = 0
+            for m_sent in eachmatch(sentence_pattern, match_block)
+                push!(sentences, m_sent.match)
+                push!(group_ids, i + j) # all sentences to have separate group
+                j += 1
+            end
+        end
+        ## increment counter
+        i += j
+    end
+
+    return sentences, group_ids
 end

--- a/src/Experimental/RAGTools/utils.jl
+++ b/src/Experimental/RAGTools/utils.jl
@@ -204,7 +204,7 @@ function split_into_code_and_sentences(input::Union{String, SubString{String}})
     pattern = r"(```[\s\S]+?```)|(`[^`]*?`)|([^`]+)"
 
     ## Patterns for sentences: newline, tab, bullet, enumerate list, sentence, any left out characters
-    sentence_pattern = r"(\n|\t|^\s*[*+-]\s*|^\s*\d+\.\s+|[^\n\t*+-.!?]+|[\n\t*+-.!?])"ms
+    sentence_pattern = r"(\n|\t|^\s*[*+-]\s*|^\s*\d+\.\s+|[^\n\t*+\-.!?]+[\n\t*+\-.!?]*|[*+\-.!?])"ms
 
     # Initialize an empty array to store the split sentences
     sentences = SubString{String}[]

--- a/src/Experimental/RAGTools/utils.jl
+++ b/src/Experimental/RAGTools/utils.jl
@@ -1,3 +1,15 @@
+# STOPWORDS - used for annotation highlighting
+# Just a small list to
+const STOPWORDS = [
+    "a", "an", "the", "and", "is", "isn't", "are", "aren't", "be", "was", "wasn't", "been",
+    "will", "won't", "would", "wouldn't",
+    "have", "haven't", "has", "hasn't", "do", "don't", "does", "did", "to",
+    "from", "go", "goes", "went", "gone", "at",
+    "into", "on", "or", "but", "per", "so", "then", "than",
+    "what", "why", "who", "where", "whom", "which", "that", "with",
+    "its", "their"] |> x -> vcat(x, titlecase.(x))
+# "if","else","elseif", "in", "for", "let","for", 
+
 # Utility to check model suitability
 function _check_aiextract_capability(model::AbstractString)
     # Check that the provided model is known and that it is an OpenAI model (for the aiextract function to work)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -476,8 +476,11 @@ macro timeout(seconds, expr_to_run, expr_when_fails)
     end
 end
 
-"Utility for rendering the conversation (vector of messages) as markdown. REQUIRES the Markdown package to load the extension!"
+"Utility for rendering the conversation (vector of messages) as markdown. REQUIRES the Markdown package to load the extension! See also `pprint`"
 function preview end
+
+"Utility for pretty printing PromptingTools types in REPL."
+function pprint end
 
 """
     auth_header(api_key::Union{Nothing, AbstractString};

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -168,6 +168,51 @@ function split_by_length(text, separators::Vector{String}; max_length)
 end
 
 """
+    wrap_string(str::String,
+        text_width::Int = 20;
+        newline::Union{AbstractString, AbstractChar} = '\n')
+
+Breaks a string into lines of a given `text_width`.
+Optionally, you can specify the `newline` character or string to use.
+
+# Example:
+
+```julia
+wrap_string("Certainly, here's a function in Julia that will wrap a string according to the specifications:", 10) |> print
+```
+"""
+function wrap_string(str::AbstractString,
+        text_width::Int = 20;
+        newline::Union{AbstractString, AbstractChar} = '\n')
+    words = split(str)
+    output = IOBuffer()
+    current_line_length = 0
+
+    for word in words
+        word_length = length(word)
+        if current_line_length + word_length > text_width
+            if current_line_length > 0
+                write(output, newline)
+                current_line_length = 0
+            end
+            while word_length > text_width
+                write(output, word[1:(text_width - 1)], "-$newline")
+                word = word[text_width:end]
+                word_length -= text_width - 1
+            end
+        end
+        if current_line_length > 0
+            write(output, ' ')
+            current_line_length += 1
+        end
+        write(output, word)
+        current_line_length += word_length
+    end
+
+    return String(take!(output))
+end;
+
+"""
     length_longest_common_subsequence(itr1, itr2)
 
 Compute the length of the longest common subsequence between two sequences (ie, the higher the number, the better the match).
@@ -481,6 +526,16 @@ function preview end
 
 "Utility for pretty printing PromptingTools types in REPL."
 function pprint end
+
+# show fallback
+function pprint(io::IO, anything::Any; text_width::Int = displaysize(io)[2])
+    show(io, anything)
+end
+
+function pprint(anything::Any;
+        text_width = displaysize(stdout)[2])
+    pprint(stdout, anything; text_width)
+end
 
 """
     auth_header(api_key::Union{Nothing, AbstractString};

--- a/test/Experimental/RAGTools/annotation.jl
+++ b/test/Experimental/RAGTools/annotation.jl
@@ -1,0 +1,693 @@
+using Test
+
+@testset "tokenize" begin
+    # Test basic tokenization with common delimiters
+    @test tokenize("Hello, world!") == ["Hello", ",", " ", "world", "!"]
+
+    # Test tokenization with various whitespace characters
+    @test tokenize("New\nLine\tTab") == ["New", "\n", "Line", "\t", "Tab"]
+
+    # Test tokenization with a mix of punctuation and words
+    @test tokenize("Yes! This works.") == ["Yes", "!", " ", "This", " ", "works", "."]
+
+    # Test tokenization of a string with no delimiters, i.e., a single word
+    @test tokenize("SingleWord") == ["SingleWord"]
+
+    # Test tokenization of an empty string
+    @test tokenize("") == []
+end
+
+using Test
+
+@testset "trigrams" begin
+    # Test generating trigrams from a string of sufficient length
+    @test trigrams("hello") == ["hel", "ell", "llo"]
+
+    # Test generating trigrams from a string with exactly 3 characters
+    @test trigrams("cat") == ["cat"]
+
+    # Test with a string of length less than 3, expecting an empty array
+    @test trigrams("no") == []
+
+    # Test with an empty string, also expecting an empty array
+    @test trigrams("") == []
+
+    # Test a case with special characters and spaces
+    @test trigrams("a b c") == ["a b", " b ", "b c"]
+end
+
+using Test
+
+@testset "trigrams_hashed" begin
+    # Test hashing trigrams from a string of sufficient length
+    # Since hashing produces unique UInt64 values, we test for the set's length instead of specific values
+    @test length(trigrams_hashed("hello")) == 3
+
+    # Test hashing a string with exactly 3 characters
+    # Expecting a set with 1 unique hash value because there's only one trigram
+    @test length(trigrams_hashed("cat")) == 1
+
+    # Test with a string of length less than 3, expecting a set with 1 hash value
+    @test length(trigrams_hashed("no")) == 1
+
+    # Test with an empty string, expecting a set with 1 hash value because the empty string itself is hashed
+    @test length(trigrams_hashed("")) == 1
+
+    # Test to ensure no duplicate hash values in case of repeating trigrams
+    # "ababab" will generate "aba", "bab", "aba", "bab" - only two unique trigrams when hashed
+    @test length(trigrams_hashed("ababab")) == 2
+
+    # Test a unique case with special characters to ensure hashing works across different character sets
+    # We use length check due to unpredictability of hash values
+    @test length(trigrams_hashed("a!@")) == 1
+end
+
+using Test
+
+@testset "token_with_boundaries" begin
+    # Test with no surrounding tokens
+    @test token_with_boundaries(nothing, "current", nothing) == "current"
+
+    # Test with both surrounding tokens being single characters (should concatenate all)
+    @test token_with_boundaries("a", "current", "b") == "acurrentb"
+
+    # Test with only previous token being a single character (should prepend it)
+    @test token_with_boundaries("a", "current", nothing) == "acurrent"
+
+    # Test with only next token being a single character (should append it)
+    @test token_with_boundaries(nothing, "current", "b") == "currentb"
+
+    # Test with both surrounding tokens but only next token being a single character (should append next token)
+    @test token_with_boundaries("previous", "current", "b") == "currentb"
+
+    # Test with both surrounding tokens but only previous token being a single character (should prepend previous token)
+    @test token_with_boundaries("a", "current", "next") == "acurrent"
+
+    # Test with neither surrounding tokens being single characters (should return the current token unchanged)
+    @test token_with_boundaries("previous", "current", "next") == "current"
+
+    # Test with single character current token and no surrounding tokens (should return the current token unchanged)
+    @test token_with_boundaries(nothing, "c", nothing) == "c"
+end
+
+using Test
+
+@testset "text_to_trigrams" begin
+    # Test converting basic text into trigrams
+    @test text_to_trigrams("This is a test.") ==
+          ["Thi", "his", "is", "is", "a", "tes", "est"]
+
+    # Test that spaces and punctuation are treated as separate tokens and don't produce trigrams
+    @test text_to_trigrams("Hello, world!") ==
+          ["Hel", "ell", "llo", ",", "wor", "orl", "rld", "!"]
+
+    # Test with a string that includes single-character tokens affecting neighboring tokens
+    # Expecting the single-character tokens to not produce separate trigrams but to influence surrounding tokens
+    @test text_to_trigrams("A cat.") == ["A c", "cat", "."]
+
+    # Test with an empty string, expecting an empty array
+    @test text_to_trigrams("") == []
+
+    # Test a complex case with special characters, spaces, and punctuation
+    # This checks that the function handles various types of tokens correctly
+    @test text_to_trigrams("It's rain-ing!") ==
+          ["It'", "'s", "rai", "ain", "-in", "ing", "!"]
+
+    # Test to ensure correct handling of multiple adjacent spaces and punctuation
+    # Spaces and punctuation should be treated as tokens but not produce trigrams
+    @test text_to_trigrams("Wow...  That's amazing!") ==
+          ["Wow", ".", ".", ".", "Tha", "hat", "'s", "ama", "maz", "zin", "ing", "!"]
+end
+
+using Test
+
+@testset "text_to_trigrams_hashed" begin
+    # Test basic text conversion to hashed trigrams
+    # Checking for set size rather than specific hashes due to unpredictable hash values
+    @test length(text_to_trigrams_hashed("This is a test.")) > 0
+
+    # Test that unique trigrams produce a set of unique hashes
+    # "hello" produces 3 unique trigrams, expecting 3 unique hash values
+    @test length(text_to_trigrams_hashed("hello")) == 3
+
+    # Test with a string of repeating characters, which should still produce unique trigrams
+    # "aaa" will only produce one unique trigram "aaa", hence one hash
+    @test length(text_to_trigrams_hashed("aaa")) == 1
+
+    # Test handling of special characters and spaces
+    # Expecting different hash values for different configurations of special characters
+    @test length(text_to_trigrams_hashed("a!@ #$%^")) > 0
+
+    # Test with an empty string, which should still produce a single hash value for the empty string
+    @test length(text_to_trigrams_hashed("")) == 1
+
+    # Test to ensure no duplicate hash values in case of repeating patterns within the input string
+    # For a pattern that repeats, like "ababab", the number of unique trigrams should be less than the total trigrams
+    # However, due to hashing direct repeats might still only produce a small set of unique hashes
+    @test length(text_to_trigrams_hashed("ababab")) <= 4
+
+    # Test a complex sentence with various characters, expecting a mix of unique hashes
+    # The exact number of unique hashes is less important than ensuring we're getting a non-zero, plausible count
+    @test length(text_to_trigrams_hashed("Complex sentence: 123!")) > 0
+end
+
+using Test
+
+@testset "split_sentences" begin
+    # Test basic sentence splitting
+    @test begin
+        sentences, group_ids = split_sentences("This is a test. This is another test.")
+        sentences == ["This is a test.", " This is another test."] &&
+            all(x -> x == 1, group_ids)
+    end
+
+    # Test handling of code blocks and inline code
+    @test begin
+        sentences, group_ids = split_sentences("Here is a code block: ```code here``` and `inline code`.")
+        sentences ==
+        ["Here is a code block: ", "```code here```", " and ", "`inline code`", "."] &&
+            group_ids == [1, 2, 3, 4, 5]
+    end
+
+    # Test with multiple code blocks and inline codes
+    @test begin
+        sentences, group_ids = split_sentences("```block1``` `inline1` Text. ```block2```")
+        sentences == ["```block1```", " `inline1` Text. ", "```block2```"] &&
+            group_ids == [1, 2, 3]
+    end
+
+    # Test with sentences containing various punctuation
+    @test begin
+        sentences, group_ids = split_sentences("Is this a question? Yes! It is.")
+        sentences == ["Is this a question?", " Yes!", " It is."] &&
+            all(x -> x == 1, group_ids)
+    end
+
+    # Test an empty string, expecting empty arrays
+    @test begin
+        sentences, group_ids = split_sentences("")
+        isempty(sentences) && isempty(group_ids)
+    end
+
+    # Test with only code blocks and no normal text
+    @test begin
+        sentences, group_ids = split_sentences("```block1``` ```block2```")
+        sentences == ["```block1```", " ```block2```"] && group_ids == [1, 2]
+    end
+
+    # Test with newline characters and tabs, ensuring they're captured as part of sentences
+    @test begin
+        sentences, group_ids = split_sentences("Line one.\nLine two.\tLine three.")
+        sentences == ["Line one.", "\nLine two.", "\tLine three."] &&
+            all(x -> x == 1, group_ids)
+    end
+end
+
+using Test
+
+# Mocking necessary components for the tests
+abstract type AbstractAnnotater end
+struct TrigramAnnotater <: AbstractAnnotater end
+@kwdef mutable struct Styler
+    color::Symbol = :nothing
+    bold::Bool = false
+    underline::Bool = false
+    italic::Bool = false
+end
+@kwdef mutable struct AnnotatedNode{T}
+    group_id::Int = 0
+    parent::Union{AnnotatedNode, Nothing} = nothing
+    children::Vector{AnnotatedNode} = AnnotatedNode[]
+    score::Union{Nothing, Float64} = nothing
+    hits::Int = 0
+    content::T = SubString{String}("")
+    sources::Vector{Int} = Int[]
+    style::Styler = Styler()
+end
+
+# Implementing a basic tokenize function required for trigram_support!
+function tokenize(input::Union{String, SubString{String}})
+    pattern = r"(\s+|=>|\(;|,|\.|\(|\)|\{|\}|\[|\]|;|:|\+|-|\*|/|<|>|=|&|\||!|@|#|\$|%|\^|~|`|\"|'|\w+)"
+    SubString{String}[m.match for m in eachmatch(pattern, input)]
+end
+
+# A basic trigrams function required for context preparation
+function trigrams(input_string::AbstractString)
+    trigrams = SubString{String}[]
+    if length(input_string) >= 3
+        for i in 1:(length(input_string) - 2)
+            push!(trigrams, @views input_string[i:(i + 2)])
+        end
+    end
+    return trigrams
+end
+
+@testset "trigram_support!" begin
+    # Preparing a mock context of trigrams for testing
+    context_trigrams = [trigrams("This is a test."), trigrams("Another test."),
+        trigrams("More content here.")]
+
+    # Test updating a node with no matching trigrams in context
+    @test begin
+        node = AnnotatedNode(content = "Unrelated content")
+        trigram_support!(node, context_trigrams)
+        isempty(node.children) && isnothing(node.score) && node.hits == 0
+    end
+
+    # Test updating a node with partial matching trigrams in context
+    @test begin
+        node = AnnotatedNode(content = "This is")
+        trigram_support!(node, context_trigrams)
+        !isempty(node.children) && node.score > 0 &&
+            node.hits < length(tokenize(node.content))
+    end
+
+    # Test updating a node with full matching trigrams in context
+    @test begin
+        node = AnnotatedNode(content = "Another test.")
+        trigram_support!(node, context_trigrams)
+        !isempty(node.children) && !isnothing(node.score) &&
+            node.hits == length(tokenize(node.content))
+    end
+
+    # Test handling of a single-character content, which should not form trigrams
+    @test begin
+        node = AnnotatedNode(content = "A")
+        trigram_support!(node, context_trigrams)
+        !isempty(node.children) && isnothing(node.score) && node.hits == 0
+    end
+
+    # Test with an empty content, expecting no children and no score
+    @test begin
+        node = AnnotatedNode(content = "")
+        trigram_support!(node, context_trigrams)
+        isempty(node.children) && isnothing(node.score)
+    end
+end
+
+using Test
+
+# Assuming required structures and helper functions are already defined.
+# Mock context trigrams preparation function for testing
+function prepare_context_trigrams(context::AbstractVector)
+    # This mock function would typically convert context sentences to trigrams
+    # For simplicity, we return a mock representation
+    return [trigrams(sentence) for sentence in context]
+end
+
+@testset "annotate_support" begin
+    # Context setup for testing
+    annotater = TrigramAnnotater()
+    context = [
+        "This is a test context.", "Another context sentence.", "Final piece of context."]
+    context_trigrams = prepare_context_trigrams(context)
+
+    # Test annotating an answer that partially matches the context
+    @test begin
+        answer = "This is a test answer. It has multiple sentences."
+        annotated_root = annotate_support(annotater, answer, context_trigrams)
+        !isempty(annotated_root.children) && length(annotated_root.children) == 2
+    end
+
+    # Test annotating an answer that fully matches the context
+    @test begin
+        answer = "This is a test context. Another context sentence."
+        annotated_root = annotate_support(annotater, answer, context_trigrams)
+        all(child -> !isnothing(child.score) && child.hits > 0, annotated_root.children)
+    end
+
+    # Test annotating an answer with no matching content in the context
+    @test begin
+        answer = "Unrelated content here. Completely different."
+        annotated_root = annotate_support(annotater, answer, context_trigrams)
+        all(child -> isnothing(child.score), annotated_root.children)
+    end
+
+    # Test annotating an empty answer, expecting a root node with no children
+    @test begin
+        answer = ""
+        annotated_root = annotate_support(annotater, answer, context_trigrams)
+        isempty(annotated_root.children)
+    end
+
+    # Test handling of special characters and punctuation in the answer
+    @test begin
+        answer = "Special characters: !@#$%. Punctuation marks: ,;:."
+        annotated_root = annotate_support(annotater, answer, context_trigrams)
+        !isempty(annotated_root.children) && length(annotated_root.children) == 2
+    end
+end
+
+using Test
+using AbstractTrees
+
+# Assuming the AnnotatedNode struct and relevant methods are defined as per the previous context
+
+@testset "AnnotatedNode and its Interface" begin
+    # Test node creation with default values
+    @test begin
+        node = AnnotatedNode()
+        @test node.group_id == 0
+        @test isnothing(node.parent)
+        @test isempty(node.children)
+        @test isnothing(node.score)
+        @test node.hits == 0
+        @test node.content == ""
+        @test isempty(node.sources)
+        @test typeof(node.style) == Styler && node.style.color == :nothing
+    end
+
+    # Test node creation with specific values
+    @test begin
+        parent_node = AnnotatedNode(content = "parent")
+        child_node = AnnotatedNode(parent = parent_node, content = "child")
+        @test child_node.parent === parent_node
+        @test child_node.content == "child"
+    end
+
+    # Test adding a child node updates children array correctly
+    @test begin
+        parent_node = AnnotatedNode()
+        child_node = AnnotatedNode(content = "child")
+        push!(parent_node.children, child_node)
+        @test length(parent_node.children) == 1
+        @test parent_node.children[1] === child_node
+    end
+
+    # Test AbstractTrees interface compatibility
+    @test begin
+        parent_node = AnnotatedNode(content = "parent")
+        child_node1 = AnnotatedNode(content = "child1")
+        child_node2 = AnnotatedNode(content = "child2")
+        push!(parent_node.children, child_node1)
+        push!(parent_node.children, child_node2)
+
+        @test AbstractTrees.children(parent_node) == [child_node1, child_node2]
+        @test AbstractTrees.parent(child_node1) === parent_node
+        @test AbstractTrees.parent(child_node2) === parent_node
+    end
+
+    # Test nodevalue and childtype methods for tree traversal
+    @test begin
+        node = AnnotatedNode(content = "root", group_id = 1)
+        child_node = AnnotatedNode(content = "child", group_id = 2)
+        push!(node.children, child_node)
+        @test AbstractTrees.nodevalue(node) == 1
+        @test AbstractTrees.childtype(node) === AnnotatedNode
+    end
+
+    # Test pprint function for a single node
+    @test begin
+        node = AnnotatedNode(content = "test", group_id = 123)
+        io = IOBuffer()
+        pprint(io, node)
+        @test occursin("AnnotatedNode(id: 123, 4)", String(take!(io)))
+    end
+end
+
+using Test
+
+# Assuming the Styler, AnnotatedNode, and TrigramAnnotater structures are already defined as per previous contexts
+
+# Test setup for set_node_style!
+function set_node_style!(annotater::TrigramAnnotater, node::AnnotatedNode;
+        low_threshold::Float64 = 0.5, high_threshold::Float64 = 1.0,
+        high_styler::Styler = Styler(color = :green, bold = false), low_styler::Styler = Styler(
+            color = :red, bold = false),
+        bold_multihits::Bool = true)
+    node.style = if isnothing(node.score)
+        Styler()
+    elseif node.score >= high_threshold
+        high_styler
+    elseif node.score >= low_threshold
+        low_styler
+    else
+        Styler()
+    end
+
+    if node.hits > 1 && bold_multihits
+        node.style.bold = true
+    end
+
+    return node
+end
+
+@testset "set_node_style!" begin
+    annotater = TrigramAnnotater()
+
+    # Test with a high score exceeding high_threshold
+    @test begin
+        node = AnnotatedNode(score = 0.9)
+        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
+        @test node.style.color == :green && node.style.bold == false
+    end
+
+    # Test with a score between high_threshold and low_threshold
+    @test begin
+        node = AnnotatedNode(score = 0.4)
+        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
+        @test node.style.color == :red && node.style.bold == false
+    end
+
+    # Test with a score below low_threshold
+    @test begin
+        node = AnnotatedNode(score = 0.2)
+        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
+        @test node.style.color == :nothing && node.style.bold == false
+    end
+
+    # Test applying bold style for multiple hits
+    @test begin
+        node = AnnotatedNode(score = 0.9, hits = 2)
+        set_node_style!(annotater, node; high_threshold = 0.8, bold_multihits = true)
+        @test node.style.color == :green && node.style.bold == true
+    end
+
+    # Test not applying bold style when bold_multihits is false
+    @test begin
+        node = AnnotatedNode(score = 0.9, hits = 2)
+        set_node_style!(annotater, node; high_threshold = 0.8, bold_multihits = false)
+        @test node.style.color == :green && node.style.bold == false
+    end
+
+    # Test with isnothing(node.score), expecting default style
+    @test begin
+        node = AnnotatedNode(score = nothing)
+        set_node_style!(annotater, node)
+        @test node.style.color == :nothing && node.style.bold == false
+    end
+end
+
+using Test
+
+# Assuming the Styler, AnnotatedNode, and TrigramAnnotater structures are already defined as per previous contexts
+
+# Test setup for set_node_style!
+function set_node_style!(annotater::TrigramAnnotater, node::AnnotatedNode;
+        low_threshold::Float64 = 0.5, high_threshold::Float64 = 1.0,
+        high_styler::Styler = Styler(color = :green, bold = false), low_styler::Styler = Styler(
+            color = :red, bold = false),
+        bold_multihits::Bool = true)
+    node.style = if isnothing(node.score)
+        Styler()
+    elseif node.score >= high_threshold
+        high_styler
+    elseif node.score >= low_threshold
+        low_styler
+    else
+        Styler()
+    end
+
+    if node.hits > 1 && bold_multihits
+        node.style.bold = true
+    end
+
+    return node
+end
+
+@testset "set_node_style!" begin
+    annotater = TrigramAnnotater()
+
+    # Test with a high score exceeding high_threshold
+    @test begin
+        node = AnnotatedNode(score = 0.9)
+        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
+        @test node.style.color == :green && node.style.bold == false
+    end
+
+    # Test with a score between high_threshold and low_threshold
+    @test begin
+        node = AnnotatedNode(score = 0.4)
+        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
+        @test node.style.color == :red && node.style.bold == false
+    end
+
+    # Test with a score below low_threshold
+    @test begin
+        node = AnnotatedNode(score = 0.2)
+        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
+        @test node.style.color == :nothing && node.style.bold == false
+    end
+
+    # Test applying bold style for multiple hits
+    @test begin
+        node = AnnotatedNode(score = 0.9, hits = 2)
+        set_node_style!(annotater, node; high_threshold = 0.8, bold_multihits = true)
+        @test node.style.color == :green && node.style.bold == true
+    end
+
+    # Test not applying bold style when bold_multihits is false
+    @test begin
+        node = AnnotatedNode(score = 0.9, hits = 2)
+        set_node_style!(annotater, node; high_threshold = 0.8, bold_multihits = false)
+        @test node.style.color == :green && node.style.bold == false
+    end
+
+    # Test with isnothing(node.score), expecting default style
+    @test begin
+        node = AnnotatedNode(score = nothing)
+        set_node_style!(annotater, node)
+        @test node.style.color == :nothing && node.style.bold == false
+    end
+end
+
+using Test
+
+# Assuming the Styler, AnnotatedNode, and TrigramAnnotater structures are already defined as per previous contexts
+
+# Mock implementation for align_node_styles!
+function align_node_styles!(
+        annotater::TrigramAnnotater, nodes::Vector{AnnotatedNode}; kwargs...)
+    for i in 2:(length(nodes) - 1)
+        prev, current, next = nodes[i - 1], nodes[i], nodes[i + 1]
+        if isnothing(current.score) && prev.style == next.style
+            current.style = prev.style
+        end
+    end
+end
+
+@testset "align_node_styles!" begin
+    annotater = TrigramAnnotater()
+
+    # Setup for tests: Create a sequence of nodes with varied styles
+    node1 = AnnotatedNode(style = Styler(color = :red), score = 1.0)
+    node2 = AnnotatedNode(style = Styler(), score = nothing) # Target for style alignment
+    node3 = AnnotatedNode(style = Styler(color = :red), score = 1.0)
+    nodes = [node1, node2, node3]
+
+    # Test aligning styles in a simple sequence
+    @test begin
+        align_node_styles!(annotater, nodes)
+        @test nodes[2].style.color == :red
+    end
+
+    # Test with non-matching surrounding styles, expecting no change
+    @test begin
+        node4 = AnnotatedNode(style = Styler(color = :green), score = 1.0) # Different style
+        node5 = AnnotatedNode(style = Styler(), score = nothing) # Target for style alignment
+        node6 = AnnotatedNode(style = Styler(color = :red), score = 1.0)
+        nodes2 = [node4, node5, node6]
+
+        align_node_styles!(annotater, nodes2)
+        @test nodes2[2].style.color == :nothing # Should remain unchanged
+    end
+
+    # Test with first and last nodes, which should not be aligned
+    @test begin
+        node7 = AnnotatedNode(style = Styler(), score = nothing) # First node
+        node8 = AnnotatedNode(style = Styler(color = :blue), score = 1.0)
+        node9 = AnnotatedNode(style = Styler(), score = nothing) # Last node
+        nodes3 = [node7, node8, node9]
+
+        align_node_styles!(annotater, nodes3)
+        @test nodes3[1].style.color == :nothing && nodes3[3].style.color == :nothing # Should remain unchanged
+    end
+
+    # Test aligning styles with more complex sequences
+    @test begin
+        node10 = AnnotatedNode(style = Styler(color = :blue), score = 1.0)
+        node11 = AnnotatedNode(style = Styler(), score = nothing) # Target for style alignment
+        node12 = AnnotatedNode(style = Styler(color = :blue), score = 1.0)
+        node13 = AnnotatedNode(style = Styler(), score = nothing) # Another target, but no adjacent same styles
+        nodes4 = [node10, node11, node12, node13]
+
+        align_node_styles!(annotater, nodes4)
+        @test nodes4[2].style.color == :blue && nodes4[4].style.color == :nothing
+    end
+end
+
+using Test
+
+# Mocking required components and helper functions
+@kwdef mutable struct Styler
+    color::Symbol = :nothing
+    bold::Bool = false
+    underline::Bool = false
+    italic::Bool = false
+end
+
+@kwdef mutable struct AnnotatedNode{T = String}
+    content::T = ""
+    children::Vector{AnnotatedNode{T}} = AnnotatedNode{T}[]
+    style::Styler = Styler()
+end
+
+function pprint(io::IO, node::AnnotatedNode{T}) where {T}
+    if isempty(node.children)
+        printstyled(io, node.content; bold = node.style.bold, color = node.style.color,
+            underline = node.style.underline, italic = node.style.italic)
+    else
+        for child in node.children
+            pprint(io, child)
+        end
+    end
+end
+
+@testset "pprint" begin
+    # Test pprint with a single node
+    @test begin
+        node = AnnotatedNode(content = "root", style = Styler(color = :red, bold = true))
+        io = IOBuffer()
+        pprint(io, node)
+        @test String(take!(io)) == "root" # Simplified check due to lack of styled output in tests
+    end
+
+    # Test pprint with nested children
+    @test begin
+        parent_node = AnnotatedNode(content = "parent")
+        child_node1 = AnnotatedNode(content = "child1", style = Styler(bold = true))
+        child_node2 = AnnotatedNode(content = "child2", style = Styler(italic = true))
+        push!(parent_node.children, child_node1)
+        push!(parent_node.children, child_node2)
+
+        io = IOBuffer()
+        pprint(io, parent_node)
+        output = String(take!(io))
+        expected_output = "child1child2" # Simplified check; in practice, validate styled output
+        @test output == expected_output
+    end
+
+    # Test pprint with empty content
+    @test begin
+        node = AnnotatedNode()
+        io = IOBuffer()
+        pprint(io, node)
+        @test String(take!(io)) == ""
+    end
+
+    # Test pprint with complex hierarchy
+    @test begin
+        parent_node = AnnotatedNode(content = "parent", style = Styler(color = :blue))
+        child_node = AnnotatedNode(content = "child", style = Styler(underline = true))
+        grandchild_node = AnnotatedNode(content = "grandchild", style = Styler(bold = true))
+
+        push!(child_node.children, grandchild_node)
+        push!(parent_node.children, child_node)
+
+        io = IOBuffer()
+        pprint(io, parent_node)
+        output = String(take!(io))
+        expected_output = "childgrandchild" # Simplified; actual output would include styles
+        @test output == expected_output
+    end
+end

--- a/test/Experimental/RAGTools/annotation.jl
+++ b/test/Experimental/RAGTools/annotation.jl
@@ -1,160 +1,109 @@
 using PromptingTools.Experimental.RAGTools: AnnotatedNode, set_node_style!,
-                                            align_node_styles!, TrigramAnnotater
+                                            align_node_styles!, TrigramAnnotater, Styler,
+                                            pprint
 using PromptingTools.Experimental.RAGTools: trigram_support!, add_node_metadata!,
                                             annotate_support
 
 @testset "AnnotatedNode" begin
     # Test node creation with default values
-    @test begin
-        node = AnnotatedNode()
-        @test node.group_id == 0
-        @test isnothing(node.parent)
-        @test isempty(node.children)
-        @test isnothing(node.score)
-        @test node.hits == 0
-        @test node.content == ""
-        @test isempty(node.sources)
-        @test typeof(node.style) == Styler && node.style.color == :nothing
-    end
+    node = AnnotatedNode()
+    @test node.group_id == 0
+    @test isnothing(node.parent)
+    @test isempty(node.children)
+    @test isnothing(node.score)
+    @test node.hits == 0
+    @test node.content == ""
+    @test isempty(node.sources)
+    @test typeof(node.style) == Styler && node.style.color == :nothing
 
     # Test node creation with specific values
-    @test begin
-        parent_node = AnnotatedNode(content = "parent")
-        child_node = AnnotatedNode(parent = parent_node, content = "child")
-        @test child_node.parent === parent_node
-        @test child_node.content == "child"
-    end
+    parent_node = AnnotatedNode(content = "parent")
+    child_node = AnnotatedNode(parent = parent_node, content = "child")
+    push!(parent_node.children, child_node)
+    child_node2 = AnnotatedNode(parent = parent_node, content = "child2")
+    push!(parent_node.children, child_node2)
 
-    # Test adding a child node updates children array correctly
-    @test begin
-        parent_node = AnnotatedNode()
-        child_node = AnnotatedNode(content = "child")
-        push!(parent_node.children, child_node)
-        @test length(parent_node.children) == 1
-        @test parent_node.children[1] === child_node
-    end
+    @test child_node.parent === parent_node
+    @test child_node.content == "child"
+    @test length(parent_node.children) == 2
+    @test parent_node.children[1] === child_node
 
     # Test AbstractTrees interface compatibility
-    @test begin
-        parent_node = AnnotatedNode(content = "parent")
-        child_node1 = AnnotatedNode(content = "child1")
-        child_node2 = AnnotatedNode(content = "child2")
-        push!(parent_node.children, child_node1)
-        push!(parent_node.children, child_node2)
-
-        @test AbstractTrees.children(parent_node) == [child_node1, child_node2]
-        @test AbstractTrees.parent(child_node1) === parent_node
-        @test AbstractTrees.parent(child_node2) === parent_node
-    end
+    @test AbstractTrees.children(parent_node) == [child_node, child_node2]
+    @test AbstractTrees.parent(child_node) === parent_node
+    @test AbstractTrees.parent(child_node2) === parent_node
 
     # Test nodevalue and childtype methods for tree traversal
-    @test begin
-        node = AnnotatedNode(content = "root", group_id = 1)
-        child_node = AnnotatedNode(content = "child", group_id = 2)
-        push!(node.children, child_node)
-        @test AbstractTrees.nodevalue(node) == 1
-        @test AbstractTrees.childtype(node) === AnnotatedNode
-    end
+    @test AbstractTrees.nodevalue(child_node) == "child(nothing)"
+    @test AbstractTrees.childtype(node) === AnnotatedNode
+end
 
+@testset "AnnotatedNode-pprint" begin
     # Test pprint function for a single node
-    @test begin
-        node = AnnotatedNode(content = "test", group_id = 123)
-        io = IOBuffer()
-        pprint(io, node)
-        @test occursin("AnnotatedNode(id: 123, 4)", String(take!(io)))
-    end
+    node = AnnotatedNode(content = "test", group_id = 123)
+    io = IOBuffer()
+    pprint(io, node)
+    @test String(take!(io)) == "test"
+
+    ## Multiple nodes
+    parent_node = AnnotatedNode(content = "parent")
+    child_node = AnnotatedNode(parent = parent_node, content = "child")
+    push!(parent_node.children, child_node)
+    child_node2 = AnnotatedNode(parent = parent_node, content = "child2")
+    push!(parent_node.children, child_node2)
+    io = IOBuffer()
+    pprint(io, parent_node)
+    output = String(take!(io))
+    # iterate over all nodes with no children
+    @test output == "childchild2"
+
+    # Add one more child
+    child_node3 = AnnotatedNode(parent = child_node2, content = "child3")
+    push!(child_node2.children, child_node3)
+    io = IOBuffer()
+    pprint(io, parent_node)
+    output = String(take!(io))
+    @test output == "childchild3"
 end
 
 @testset "set_node_style!" begin
     annotater = TrigramAnnotater()
 
     # Test with a high score exceeding high_threshold
-    @test begin
-        node = AnnotatedNode(score = 0.9)
-        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
-        @test node.style.color == :green && node.style.bold == false
-    end
+    node = AnnotatedNode(score = 0.9)
+    set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
+    @test node.style.color == :green
+    @test node.style.bold == false
 
     # Test with a score between high_threshold and low_threshold
-    @test begin
-        node = AnnotatedNode(score = 0.4)
-        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
-        @test node.style.color == :red && node.style.bold == false
-    end
+    node = AnnotatedNode(score = 0.4)
+    set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
+    @test node.style.color == :magenta
+    @test node.style.bold == false
 
     # Test with a score below low_threshold
-    @test begin
-        node = AnnotatedNode(score = 0.2)
-        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
-        @test node.style.color == :nothing && node.style.bold == false
-    end
+    node = AnnotatedNode(score = 0.2)
+    set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
+    @test node.style.color == :nothing
+    @test node.style.bold == false
 
     # Test applying bold style for multiple hits
-    @test begin
-        node = AnnotatedNode(score = 0.9, hits = 2)
-        set_node_style!(annotater, node; high_threshold = 0.8, bold_multihits = true)
-        @test node.style.color == :green && node.style.bold == true
-    end
+    node = AnnotatedNode(score = 0.9, hits = 2)
+    set_node_style!(annotater, node; high_threshold = 0.8, bold_multihits = true)
+    @test node.style.color == :green
+    @test node.style.bold == true
 
     # Test not applying bold style when bold_multihits is false
-    @test begin
-        node = AnnotatedNode(score = 0.9, hits = 2)
-        set_node_style!(annotater, node; high_threshold = 0.8, bold_multihits = false)
-        @test node.style.color == :green && node.style.bold == false
-    end
+    node = AnnotatedNode(score = 0.9, hits = 2)
+    set_node_style!(annotater, node; high_threshold = 0.8, bold_multihits = false)
+    @test node.style.color == :green
+    @test node.style.bold == false
 
     # Test with isnothing(node.score), expecting default style
-    @test begin
-        node = AnnotatedNode(score = nothing)
-        set_node_style!(annotater, node)
-        @test node.style.color == :nothing && node.style.bold == false
-    end
-end
-
-@testset "set_node_style!" begin
-    annotater = TrigramAnnotater()
-
-    # Test with a high score exceeding high_threshold
-    @test begin
-        node = AnnotatedNode(score = 0.9)
-        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
-        @test node.style.color == :green && node.style.bold == false
-    end
-
-    # Test with a score between high_threshold and low_threshold
-    @test begin
-        node = AnnotatedNode(score = 0.4)
-        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
-        @test node.style.color == :red && node.style.bold == false
-    end
-
-    # Test with a score below low_threshold
-    @test begin
-        node = AnnotatedNode(score = 0.2)
-        set_node_style!(annotater, node; high_threshold = 0.8, low_threshold = 0.3)
-        @test node.style.color == :nothing && node.style.bold == false
-    end
-
-    # Test applying bold style for multiple hits
-    @test begin
-        node = AnnotatedNode(score = 0.9, hits = 2)
-        set_node_style!(annotater, node; high_threshold = 0.8, bold_multihits = true)
-        @test node.style.color == :green && node.style.bold == true
-    end
-
-    # Test not applying bold style when bold_multihits is false
-    @test begin
-        node = AnnotatedNode(score = 0.9, hits = 2)
-        set_node_style!(annotater, node; high_threshold = 0.8, bold_multihits = false)
-        @test node.style.color == :green && node.style.bold == false
-    end
-
-    # Test with isnothing(node.score), expecting default style
-    @test begin
-        node = AnnotatedNode(score = nothing)
-        set_node_style!(annotater, node)
-        @test node.style.color == :nothing && node.style.bold == false
-    end
+    node = AnnotatedNode(score = nothing)
+    set_node_style!(annotater, node)
+    @test node.style.color == :nothing
+    @test node.style.bold == false
 end
 
 @testset "align_node_styles!" begin
@@ -167,106 +116,41 @@ end
     nodes = [node1, node2, node3]
 
     # Test aligning styles in a simple sequence
-    @test begin
-        align_node_styles!(annotater, nodes)
-        @test nodes[2].style.color == :red
-    end
+    align_node_styles!(annotater, nodes)
+    @test nodes[2].style.color == :red
 
     # Test with non-matching surrounding styles, expecting no change
-    @test begin
-        node4 = AnnotatedNode(style = Styler(color = :green), score = 1.0) # Different style
-        node5 = AnnotatedNode(style = Styler(), score = nothing) # Target for style alignment
-        node6 = AnnotatedNode(style = Styler(color = :red), score = 1.0)
-        nodes2 = [node4, node5, node6]
+    node4 = AnnotatedNode(style = Styler(color = :green), score = 1.0) # Different style
+    node5 = AnnotatedNode(style = Styler(), score = nothing) # Target for style alignment
+    node6 = AnnotatedNode(style = Styler(color = :red), score = 1.0)
+    nodes2 = [node4, node5, node6]
 
-        align_node_styles!(annotater, nodes2)
-        @test nodes2[2].style.color == :nothing # Should remain unchanged
-    end
+    align_node_styles!(annotater, nodes2)
+    @test nodes2[2].style.color == :nothing # Should remain unchanged
 
     # Test with first and last nodes, which should not be aligned
-    @test begin
-        node7 = AnnotatedNode(style = Styler(), score = nothing) # First node
-        node8 = AnnotatedNode(style = Styler(color = :blue), score = 1.0)
-        node9 = AnnotatedNode(style = Styler(), score = nothing) # Last node
-        nodes3 = [node7, node8, node9]
+    node7 = AnnotatedNode(style = Styler(), score = nothing) # First node
+    node8 = AnnotatedNode(style = Styler(color = :blue), score = 1.0)
+    node9 = AnnotatedNode(style = Styler(), score = nothing) # Last node
+    nodes3 = [node7, node8, node9]
 
-        align_node_styles!(annotater, nodes3)
-        @test nodes3[1].style.color == :nothing && nodes3[3].style.color == :nothing # Should remain unchanged
-    end
+    align_node_styles!(annotater, nodes3)
+    @test nodes3[1].style.color == :nothing
+    @test nodes3[3].style.color == :nothing # Should remain unchanged
 
     # Test aligning styles with more complex sequences
-    @test begin
-        node10 = AnnotatedNode(style = Styler(color = :blue), score = 1.0)
-        node11 = AnnotatedNode(style = Styler(), score = nothing) # Target for style alignment
-        node12 = AnnotatedNode(style = Styler(color = :blue), score = 1.0)
-        node13 = AnnotatedNode(style = Styler(), score = nothing) # Another target, but no adjacent same styles
-        nodes4 = [node10, node11, node12, node13]
+    node10 = AnnotatedNode(style = Styler(color = :blue), score = 1.0)
+    node11 = AnnotatedNode(style = Styler(), score = nothing) # Target for style alignment
+    node12 = AnnotatedNode(style = Styler(color = :blue), score = 1.0)
+    node13 = AnnotatedNode(style = Styler(), score = nothing) # Another target, but no adjacent same styles
+    nodes4 = [node10, node11, node12, node13]
 
-        align_node_styles!(annotater, nodes4)
-        @test nodes4[2].style.color == :blue && nodes4[4].style.color == :nothing
-    end
+    align_node_styles!(annotater, nodes4)
+    @test nodes4[2].style.color == :blue
+    @test nodes4[4].style.color == :nothing
 end
 
-function pprint(io::IO, node::AnnotatedNode{T}) where {T}
-    if isempty(node.children)
-        printstyled(io, node.content; bold = node.style.bold, color = node.style.color,
-            underline = node.style.underline, italic = node.style.italic)
-    else
-        for child in node.children
-            pprint(io, child)
-        end
-    end
-end
-
-@testset "pprint" begin
-    # Test pprint with a single node
-    @test begin
-        node = AnnotatedNode(content = "root", style = Styler(color = :red, bold = true))
-        io = IOBuffer()
-        pprint(io, node)
-        @test String(take!(io)) == "root" # Simplified check due to lack of styled output in tests
-    end
-
-    # Test pprint with nested children
-    @test begin
-        parent_node = AnnotatedNode(content = "parent")
-        child_node1 = AnnotatedNode(content = "child1", style = Styler(bold = true))
-        child_node2 = AnnotatedNode(content = "child2", style = Styler(italic = true))
-        push!(parent_node.children, child_node1)
-        push!(parent_node.children, child_node2)
-
-        io = IOBuffer()
-        pprint(io, parent_node)
-        output = String(take!(io))
-        expected_output = "child1child2" # Simplified check; in practice, validate styled output
-        @test output == expected_output
-    end
-
-    # Test pprint with empty content
-    @test begin
-        node = AnnotatedNode()
-        io = IOBuffer()
-        pprint(io, node)
-        @test String(take!(io)) == ""
-    end
-
-    # Test pprint with complex hierarchy
-    @test begin
-        parent_node = AnnotatedNode(content = "parent", style = Styler(color = :blue))
-        child_node = AnnotatedNode(content = "child", style = Styler(underline = true))
-        grandchild_node = AnnotatedNode(content = "grandchild", style = Styler(bold = true))
-
-        push!(child_node.children, grandchild_node)
-        push!(parent_node.children, child_node)
-
-        io = IOBuffer()
-        pprint(io, parent_node)
-        output = String(take!(io))
-        expected_output = "childgrandchild" # Simplified; actual output would include styles
-        @test output == expected_output
-    end
-end
-
+# TODO: continue
 @testset "trigram_support!" begin
     # Preparing a mock context of trigrams for testing
     context_trigrams = [trigrams("This is a test."), trigrams("Another test."),

--- a/test/Experimental/RAGTools/evaluation.jl
+++ b/test/Experimental/RAGTools/evaluation.jl
@@ -75,7 +75,7 @@ end
 
 @testset "build_qa_evals" begin
     # test with a mock server
-    PORT = rand(9000:11000)
+    PORT = rand(10000:40000)
     PT.register_model!(; name = "mock-emb", schema = PT.CustomOpenAISchema())
     PT.register_model!(; name = "mock-meta", schema = PT.CustomOpenAISchema())
     PT.register_model!(; name = "mock-gen", schema = PT.CustomOpenAISchema())
@@ -87,8 +87,9 @@ end
 
         if content[:model] == "mock-gen"
             user_msg = last(content[:messages])
-            response = Dict(:choices => [
-                    Dict(:message => user_msg, :finish_reason => "stop"),
+            response = Dict(
+                :choices => [
+                    Dict(:message => user_msg, :finish_reason => "stop")
                 ],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
@@ -102,38 +103,41 @@ end
                     :completion_tokens => 0))
         elseif content[:model] == "mock-meta"
             user_msg = last(content[:messages])
-            response = Dict(:choices => [
+            response = Dict(
+                :choices => [
                     Dict(:finish_reason => "stop",
-                        :message => Dict(:tool_calls => [
-                            Dict(:function => Dict(:arguments => JSON3.write(MaybeMetadataItems([
-                                MetadataItem("yes", "category"),
-                            ]))))]))],
+                    :message => Dict(:tool_calls => [
+                        Dict(:function => Dict(:arguments => JSON3.write(MaybeMetadataItems([
+                        MetadataItem("yes", "category")
+                    ]))))]))],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),
                     :completion_tokens => 0))
         elseif content[:model] == "mock-qa"
             user_msg = last(content[:messages])
-            response = Dict(:choices => [
+            response = Dict(
+                :choices => [
                     Dict(:finish_reason => "stop",
-                        :message => Dict(:tool_calls => [
-                            Dict(:function => Dict(:arguments => JSON3.write(QAItem("Question",
-                                "Answer"))))]))],
+                    :message => Dict(:tool_calls => [
+                        Dict(:function => Dict(:arguments => JSON3.write(QAItem("Question",
+                        "Answer"))))]))],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),
                     :completion_tokens => 0))
         elseif content[:model] == "mock-judge"
             user_msg = last(content[:messages])
-            response = Dict(:choices => [
+            response = Dict(
+                :choices => [
                     Dict(:message => Dict(:tool_calls => [
-                        Dict(:function => Dict(:arguments => JSON3.write(JudgeAllScores(5,
-                            5,
-                            5,
-                            5,
-                            5,
-                            "Some reasons",
-                            5.0))))]))],
+                    Dict(:function => Dict(:arguments => JSON3.write(JudgeAllScores(5,
+                    5,
+                    5,
+                    5,
+                    5,
+                    "Some reasons",
+                    5.0))))]))],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),
@@ -150,7 +154,7 @@ end
         chunks = ["a", "b", "c"],
         embeddings = zeros(128, 3),
         tags = vcat(trues(2, 2), falses(1, 2)),
-        tags_vocab = ["yes", "no"],)
+        tags_vocab = ["yes", "no"])
 
     # Test for successful Q&A extraction from document chunks
     qa_evals = build_qa_evals(chunks(index),
@@ -177,7 +181,7 @@ end
         model_metadata = "mock-meta", api_kwargs = (; url = "http://localhost:$(PORT)"),
         tag_filter = :auto,
         extract_metadata = false, verbose = false,
-        return_context = true)
+        return_details = true)
 
     result = run_qa_evals(qa_evals[1], ctx;
         model_judge = "mock-judge",

--- a/test/Experimental/RAGTools/generation.jl
+++ b/test/Experimental/RAGTools/generation.jl
@@ -1,5 +1,5 @@
 using PromptingTools.Experimental.RAGTools: ChunkIndex,
-    CandidateChunks, build_context, airag
+                                            CandidateChunks, build_context, airag
 using PromptingTools.Experimental.RAGTools: MaybeMetadataItems, MetadataItem
 
 @testset "build_context" begin
@@ -8,7 +8,7 @@ using PromptingTools.Experimental.RAGTools: MaybeMetadataItems, MetadataItem
         chunks = ["a", "b", "c"],
         embeddings = zeros(128, 3),
         tags = vcat(trues(2, 2), falses(1, 2)),
-        tags_vocab = ["yes", "no"],)
+        tags_vocab = ["yes", "no"])
     candidates = CandidateChunks(index.id, [1, 2], [0.1, 0.2])
 
     # Standard Case
@@ -31,7 +31,7 @@ end
 
 @testset "airag" begin
     # test with a mock server
-    PORT = rand(20000:30000)
+    PORT = rand(20000:40000)
     PT.register_model!(; name = "mock-emb", schema = PT.CustomOpenAISchema())
     PT.register_model!(; name = "mock-meta", schema = PT.CustomOpenAISchema())
     PT.register_model!(; name = "mock-gen", schema = PT.CustomOpenAISchema())
@@ -41,8 +41,9 @@ end
 
         if content[:model] == "mock-gen"
             user_msg = last(content[:messages])
-            response = Dict(:choices => [
-                    Dict(:message => user_msg, :finish_reason => "stop"),
+            response = Dict(
+                :choices => [
+                    Dict(:message => user_msg, :finish_reason => "stop")
                 ],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
@@ -56,12 +57,13 @@ end
                     :completion_tokens => 0))
         elseif content[:model] == "mock-meta"
             user_msg = last(content[:messages])
-            response = Dict(:choices => [
+            response = Dict(
+                :choices => [
                     Dict(:finish_reason => "stop",
-                        :message => Dict(:tool_calls => [
-                            Dict(:function => Dict(:arguments => JSON3.write(MaybeMetadataItems([
-                                MetadataItem("yes", "category"),
-                            ]))))]))],
+                    :message => Dict(:tool_calls => [
+                        Dict(:function => Dict(:arguments => JSON3.write(MaybeMetadataItems([
+                        MetadataItem("yes", "category")
+                    ]))))]))],
                 :model => content[:model],
                 :usage => Dict(:total_tokens => length(user_msg[:content]),
                     :prompt_tokens => length(user_msg[:content]),
@@ -78,7 +80,7 @@ end
         chunks = ["a", "b", "c"],
         embeddings = zeros(128, 3),
         tags = vcat(trues(2, 2), falses(1, 2)),
-        tags_vocab = ["yes", "no"],)
+        tags_vocab = ["yes", "no"])
     ## Sub-calls
     question_emb = aiembed(["x", "x"];
         model = "mock-emb",
@@ -98,7 +100,7 @@ end
         model_chat = "mock-gen",
         model_metadata = "mock-meta", api_kwargs = (; url = "http://localhost:$(PORT)"),
         tag_filter = ["yes"],
-        return_context = false)
+        return_details = false)
     @test occursin("Time?", msg.content)
 
     # test kwargs passing
@@ -107,39 +109,52 @@ end
         model_chat = "mock-gen",
         model_metadata = "mock-meta",
         tag_filter = ["yes"],
-        return_context = false, aiembed_kwargs = (; api_kwargs),
+        return_details = false, aiembed_kwargs = (; api_kwargs),
         aigenerate_kwargs = (; api_kwargs), aiextract_kwargs = (; api_kwargs))
     @test occursin("Time?", msg.content)
 
     ## Test different kwargs
-    msg, ctx = airag(index; question = "Time?", model_embedding = "mock-emb",
+    msg, details = airag(index; question = "Time?", model_embedding = "mock-emb",
         model_chat = "mock-gen",
         model_metadata = "mock-meta", api_kwargs = (; url = "http://localhost:$(PORT)"),
         tag_filter = :auto,
         extract_metadata = false, verbose = false,
-        return_context = true)
-    @test ctx.context == ["1. a\nb\nc", "2. a\nb"]
-    @test ctx.emb_candidates.positions == [3, 2, 1]
-    @test ctx.emb_candidates.distances == zeros(3)
-    @test ctx.tag_candidates.positions == [1, 2]
-    @test ctx.tag_candidates.distances == ones(2)
-    @test ctx.filtered_candidates.positions == [2, 1] #re-sort
-    @test ctx.filtered_candidates.distances == 0.5ones(2)
-    @test ctx.reranked_candidates.positions == [2, 1] # no change
-    @test ctx.reranked_candidates.distances == 0.5ones(2) # no change
+        return_details = true)
+    @test details.context == ["1. a\nb\nc", "2. a\nb"]
+    @test details.emb_candidates.positions == [3, 2, 1]
+    @test details.emb_candidates.distances == zeros(3)
+    @test details.tag_candidates.positions == [1, 2]
+    @test details.tag_candidates.distances == ones(2)
+    @test details.filtered_candidates.positions == [2, 1] #re-sort
+    @test details.filtered_candidates.distances == 0.5ones(2)
+    @test details.reranked_candidates.positions == [2, 1] # no change
+    @test details.reranked_candidates.distances == 0.5ones(2) # no change
 
     ## Not tag filter
-    msg, ctx = airag(index; question = "Time?", model_embedding = "mock-emb",
+    msg, details = airag(index; question = "Time?", model_embedding = "mock-emb",
         model_chat = "mock-gen",
         model_metadata = "mock-meta", api_kwargs = (; url = "http://localhost:$(PORT)"),
         tag_filter = nothing,
-        return_context = true)
-    @test ctx.context == ["1. b\nc", "2. a\nb\nc", "3. a\nb"]
-    @test ctx.emb_candidates.positions == [3, 2, 1]
-    @test ctx.emb_candidates.distances == zeros(3)
-    @test ctx.tag_candidates == nothing
-    @test ctx.filtered_candidates.positions == [3, 2, 1] #re-sort
-    @test ctx.reranked_candidates.positions == [3, 2, 1] # no change
+        return_details = true)
+    @test details.context == ["1. b\nc", "2. a\nb\nc", "3. a\nb"]
+    @test details.emb_candidates.positions == [3, 2, 1]
+    @test details.emb_candidates.distances == zeros(3)
+    @test details.tag_candidates == nothing
+    @test details.filtered_candidates.positions == [3, 2, 1] #re-sort
+    @test details.reranked_candidates.positions == [3, 2, 1] # no change
+
+    ## Pretty printing
+    result = airag(index; question = "Time?", model_embedding = "mock-emb",
+        model_chat = "mock-gen",
+        model_metadata = "mock-meta", api_kwargs = (; url = "http://localhost:$(PORT)"),
+        tag_filter = nothing,
+        return_details = true)
+    io = IOBuffer()
+    PT.pprint(io, result)
+    result_str = String(take!(io))
+    expected_str = "--------------------\nQUESTION(s)\n--------------------\n- Time?\n\n--------------------\nANSWER\n--------------------\n# Question\n\nTime\n\n\n\n# Answer\n\n--------------------\nSOURCES\n--------------------\n1. .\n2. .\n3. ."
+    @test result_str == expected_str
+
     # clean up
     close(echo_server)
 end

--- a/test/Experimental/RAGTools/runtests.jl
+++ b/test/Experimental/RAGTools/runtests.jl
@@ -1,6 +1,8 @@
 using Test
 using SparseArrays, LinearAlgebra
 using PromptingTools.Experimental.RAGTools
+using PromptingTools
+const PT = PromptingTools
 using JSON3, HTTP
 
 @testset "RAGTools" begin

--- a/test/Experimental/RAGTools/runtests.jl
+++ b/test/Experimental/RAGTools/runtests.jl
@@ -9,5 +9,6 @@ using JSON3, HTTP
     include("preparation.jl")
     include("retrieval.jl")
     include("generation.jl")
+    include("annotation.jl")
     include("evaluation.jl")
 end

--- a/test/Experimental/RAGTools/runtests.jl
+++ b/test/Experimental/RAGTools/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using SparseArrays, LinearAlgebra
 using PromptingTools.Experimental.RAGTools
 using PromptingTools
+using AbstractTrees
 const PT = PromptingTools
 using JSON3, HTTP
 

--- a/test/Experimental/RAGTools/types.jl
+++ b/test/Experimental/RAGTools/types.jl
@@ -174,7 +174,7 @@ end
         id = Symbol("AnotherChunkIndex"))
     test_multi_index = MultiIndex(indexes = [
         test_chunk_index,
-        another_chuck_index,
+        another_chuck_index
     ])
     @test collect(test_multi_index[candidate_chunks]) == ["First chunk", "Third chunk"]
 

--- a/test/Experimental/RAGTools/utils.jl
+++ b/test/Experimental/RAGTools/utils.jl
@@ -1,5 +1,9 @@
 using PromptingTools.Experimental.RAGTools: _check_aiextract_capability,
-    merge_labeled_matrices
+                                            merge_labeled_matrices
+using PromptingTools.Experimental.RAGTools: tokenize, trigrams, trigrams_hashed
+using PromptingTools.Experimental.RAGTools: token_with_boundaries, text_to_trigrams,
+                                            text_to_trigrams_hashed
+using PromptingTools.Experimental.RAGTools: split_into_code_and_sentences
 
 @testset "_check_aiextract_capability" begin
     @test _check_aiextract_capability("gpt-3.5-turbo") == nothing
@@ -43,4 +47,236 @@ end
     @test size(merged_mat) == (4, 3)
     @test combined_vocab == ["word1", "word2", "word3"]
     @test merged_mat ≈ [1.0 2.0 0.0; 3.0 4.0 0.0; 0.0 5.0 6.0; 0.0 7.0 8.0]
+end
+
+### Text-manipulation utilities
+
+@testset "tokenize" begin
+    # Test basic tokenization with common delimiters
+    @test tokenize("Hello, world!") == ["Hello", ",", " ", "world", "!"]
+
+    # Test tokenization with various whitespace characters
+    @test tokenize("New\nLine\tTab") == ["New", "\n", "Line", "\t", "Tab"]
+
+    # Test tokenization with a mix of punctuation and words
+    @test tokenize("Yes! This works.") == ["Yes", "!", " ", "This", " ", "works", "."]
+
+    # Test tokenization of a string with no delimiters, i.e., a single word
+    @test tokenize("SingleWord") == ["SingleWord"]
+
+    # Test tokenization of an empty string
+    @test tokenize("") == []
+
+    # multi-space
+    @test tokenize("   ") == ["   "]
+
+    # Special characters for Julia code
+    @test tokenize("α β γ δ") == ["α", " ", "β", " ", "γ", " ", "δ"]
+    @test tokenize("a = (; a=1)") == ["a", " ", "=", " ", "(;", " ", "a", "=", "1", ")"]
+    @test tokenize("replace(s, \"abc\"=>\"ABC\")") ==
+          ["replace", "(", "s", ",", " ", "\"", "abc", "\"", "=>", "\"", "ABC", "\"", ")"]
+end
+
+@testset "trigrams" begin
+    # Test generating trigrams from a string of sufficient length
+    @test trigrams("hello") == ["hel", "ell", "llo"]
+
+    # Test generating trigrams from a string with exactly 3 characters
+    @test trigrams("cat") == ["cat"]
+
+    # Test with a string of length less than 3, expecting an empty array
+    @test trigrams("no") == []
+
+    # Test with an empty string, also expecting an empty array
+    @test trigrams("") == []
+
+    # Test a case with special characters and spaces
+    @test trigrams("a b c") == ["a b", " b ", "b c"]
+
+    # With boundaries
+    @test trigrams(" (cat=") == [" (c", "(ca", "cat", "at="]
+
+    # Add the token itself
+    @test trigrams("hello"; add_word = "hello") == ["hel", "ell", "llo", "hello"]
+
+    # non-standard chars
+    s = "α β γ δ"
+    @test trigrams(s) == ["α β", " β ", "β γ", " γ ", "γ δ"]
+end
+
+@testset "trigrams_hashed" begin
+    # Test hashing trigrams from a string of sufficient length
+    # Since hashing produces unique UInt64 values, we test for the set's length instead of specific values
+    @test trigrams_hashed("hello") == hash.(["hel", "ell", "llo"]) |> Set
+
+    # Test hashing a string with exactly 3 characters
+    @test trigrams_hashed("cat") == Set(hash("cat"))
+
+    # Test with a string of length less than 3, expecting a set with 1 hash value
+    @test trigrams_hashed("no") == Set()
+
+    # Test with an empty string, expecting a set with 1 hash value because the empty string itself is hashed
+    @test (trigrams_hashed("")) == Set()
+
+    # Test to ensure no duplicate hash values in case of repeating trigrams
+    # "ababab" will generate "aba", "bab", "aba", "bab" - only two unique trigrams when hashed
+    @test trigrams_hashed("ababab") == Set([hash("aba"), hash("bab")])
+
+    # Test a unique case with special characters to ensure hashing works across different character sets
+    @test trigrams_hashed("a!@") == Set(hash("a!@"))
+
+    # Add the token itself
+    @test trigrams_hashed("hello"; add_word = "hello") ==
+          hash.(["hel", "ell", "llo", "hello"]) |> Set
+
+    # special chars
+    s = "α β γ δ"
+    @test trigrams_hashed(s) == Set(hash.(["α β", " β ", "β γ", " γ ", "γ δ"]))
+end
+
+@testset "token_with_boundaries" begin
+    # Test with no surrounding tokens
+    @test token_with_boundaries(nothing, "current", nothing) == "current"
+
+    # Test with both surrounding tokens being single characters (should concatenate all)
+    @test token_with_boundaries("a", "current", "b") == "acurrentb"
+
+    # Test with only previous token being a single character (should prepend it)
+    @test token_with_boundaries("a", "current", nothing) == "acurrent"
+
+    # Test with only next token being a single character (should append it)
+    @test token_with_boundaries(nothing, "current", "b") == "currentb"
+
+    # Test with both surrounding tokens but only next token being a single character (should append next token)
+    @test token_with_boundaries("previous", "current", "b") == "currentb"
+
+    # Test with both surrounding tokens but only previous token being a single character (should prepend previous token)
+    @test token_with_boundaries("a", "current", "next") == "acurrent"
+
+    # Test with neither surrounding tokens being single characters (should return the current token unchanged)
+    @test token_with_boundaries("previous", "current", "next") == "current"
+
+    # Test with single character current token and no surrounding tokens (should return the current token unchanged)
+    @test token_with_boundaries(nothing, "c", nothing) == "c"
+end
+
+@testset "text_to_trigrams" begin
+    # Test converting basic text into trigrams
+    exp_output = [
+        "Thi", "his", "is ", "This", " is", "is ", "is", " te", "tes", "est", "st.", "test"]
+    @test text_to_trigrams("This is a test."; add_word = true) == exp_output
+
+    # Test converting without adding the word itself
+    exp_output = ["Thi", "his", "is ", " is", "is ", " te", "tes", "est", "st."]
+    @test text_to_trigrams("This is a test."; add_word = false) == exp_output
+
+    # Test that spaces and punctuation are treated as separate tokens
+    exp_output = ["Hel", "ell", "llo", "lo,", " wo", "wor", "orl", "rld", "ld!"]
+    @test text_to_trigrams("Hello, world!"; add_word = false) == exp_output
+
+    # Test with a string that includes single-character tokens affecting neighboring tokens
+    # Expecting the single-character tokens to not produce separate trigrams but to influence surrounding tokens
+    @test text_to_trigrams("A cat."; add_word = false) == [" ca", "cat", "at."]
+
+    # Test with an empty string, expecting an empty array
+    @test text_to_trigrams("") == []
+
+    # Test a complex case with special characters, spaces, and punctuation
+    # This checks that the function handles various types of tokens correctly
+    @test text_to_trigrams("It's rain-ing!"; add_word = false) ==
+          ["It'", " ra", "rai", "ain", "in-", "-in", "ing", "ng!"]
+
+    # Test to ensure correct handling of multiple adjacent spaces and punctuation
+    # Spaces and punctuation should be treated as tokens but not produce trigrams
+    @test text_to_trigrams("Wow...  That's amazing!"; add_word = false) ==
+          ["Wow", "ow.", ".  ", "Tha", "hat", "at'", " am",
+        "ama", "maz", "azi", "zin", "ing", "ng!"]
+
+    # Special characters
+    text_to_trigrams("a!@ #\$%^"; add_word = false) == []
+end
+
+@testset "text_to_trigrams_hashed" begin
+    # Test basic text conversion to hashed trigrams
+    exp_output = [
+        "Thi", "his", "is ", "This", " is", "is ", "is", " te", "tes", "est", "st.", "test"]
+    @test text_to_trigrams_hashed("This is a test."; add_word = true) ==
+          Set(hash.(exp_output))
+
+    # Test converting without adding the word itself
+    exp_output = ["Thi", "his", "is ", " is", "is ", " te", "tes", "est", "st."]
+    @test text_to_trigrams_hashed("This is a test."; add_word = false) ==
+          Set(hash.(exp_output))
+
+    # Test that unique trigrams produce a set of unique hashes
+    # "hello" produces 3 unique trigrams, expecting 3 unique hash values
+    @test length(text_to_trigrams_hashed("hello"; add_word = false)) == 3
+
+    # Test with a string of repeating characters, which should still produce unique trigrams
+    @test text_to_trigrams_hashed("A cat."; add_word = false) ==
+          Set(hash.([" ca", "cat", "at."]))
+
+    # Test handling of special characters and spaces -- nothing produces (too short)
+    text_to_trigrams_hashed("a!@ #\$%^"; add_word = false) == Set()
+
+    # Test with an empty string, it's empty
+    @test text_to_trigrams_hashed("") == Set()
+
+    # Test to ensure no duplicate hash values in case of repeating patterns within the input string
+    # For a pattern that repeats, like "ababab", the number of unique trigrams should be 2
+    @test text_to_trigrams_hashed("ababab"; add_word = false) == Set(hash.(["aba", "bab"]))
+
+    # Test a complex sentence with various characters, expecting a mix of unique hashes
+    # The exact number of unique hashes is less important than ensuring we're getting a non-zero, plausible count
+    @test text_to_trigrams_hashed("Complex sentence: 123!") ==
+          Set(hash.(text_to_trigrams("Complex sentence: 123!")))
+end
+
+@testset "split_sentences" begin
+    # Test basic sentence splitting
+    input = "This is a test. This is another test."
+    sentences, group_ids = split_into_code_and_sentences(input)
+    @test sentences == ["This is a test", ".", " This is another test", "."]
+    @test join(sentences, "") == input # lossless
+    @test group_ids == [1, 2, 3, 4]
+
+    # Test handling of code blocks and inline code
+    input = """Here is a code block: 
+      ```julia
+      code here
+      ```
+      and `inline code`."""
+    sentences, group_ids = split_into_code_and_sentences(input)
+    @test sentences == ["Here is a code block: ", "\n", "```julia", "\n",
+        "code here", "\n", "```", "\n", "and ", "`inline code`", "."]
+    @test join(sentences, "") == input
+    @test group_ids == [1, 2, 3, 3, 3, 3, 3, 4, 5, 6, 7]
+
+    ## Multi-faceted code
+    input = """Here is a code block: 
+    ```julia
+    code here
+    ```
+    and `inline code`.
+    Sentences here.
+    Bullets:
+    - I like this
+    - But does it work?
+    ```julia
+    another code
+    ```
+    1. Tester
+    Third sentence - but what happened.
+    """
+    sentences, group_ids = split_into_code_and_sentences(input)
+    @test sentences ==
+          ["Here is a code block: ", "\n", "```julia", "\n", "code here", "\n", "```",
+        "\n", "and ", "`inline code`", ".", "\n", "Sentences here", ".", "\n",
+        "Bullets:", "\n", "- ", "I like this", "\n", "- ", "But does it work",
+        "?", "\n", "```julia", "\n", "another code", "\n", "```", "\n", "1. ",
+        "Tester", "\n", "Third sentence ", "-", " but what happened", ".", "\n"]
+    @test join(sentences, "") == input
+    @test group_ids ==
+          [1, 2, 3, 3, 3, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+        18, 19, 20, 21, 21, 21, 21, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
 end

--- a/test/Experimental/RAGTools/utils.jl
+++ b/test/Experimental/RAGTools/utils.jl
@@ -232,13 +232,13 @@ end
           Set(hash.(text_to_trigrams("Complex sentence: 123!")))
 end
 
-@testset "split_sentences" begin
+@testset "split_into_code_and_sentences" begin
     # Test basic sentence splitting
     input = "This is a test. This is another test."
     sentences, group_ids = split_into_code_and_sentences(input)
-    @test sentences == ["This is a test", ".", " This is another test", "."]
+    @test sentences == ["This is a test.", " This is another test."]
     @test join(sentences, "") == input # lossless
-    @test group_ids == [1, 2, 3, 4]
+    @test group_ids == [1, 2]
 
     # Test handling of code blocks and inline code
     input = """Here is a code block: 
@@ -247,10 +247,11 @@ end
       ```
       and `inline code`."""
     sentences, group_ids = split_into_code_and_sentences(input)
-    @test sentences == ["Here is a code block: ", "\n", "```julia", "\n",
+    sentences
+    @test sentences == ["Here is a code block: \n", "```julia", "\n",
         "code here", "\n", "```", "\n", "and ", "`inline code`", "."]
     @test join(sentences, "") == input
-    @test group_ids == [1, 2, 3, 3, 3, 3, 3, 4, 5, 6, 7]
+    @test group_ids == [1, 2, 2, 2, 2, 2, 3, 4, 5, 6]
 
     ## Multi-faceted code
     input = """Here is a code block: 
@@ -270,13 +271,11 @@ end
     """
     sentences, group_ids = split_into_code_and_sentences(input)
     @test sentences ==
-          ["Here is a code block: ", "\n", "```julia", "\n", "code here", "\n", "```",
-        "\n", "and ", "`inline code`", ".", "\n", "Sentences here", ".", "\n",
-        "Bullets:", "\n", "- ", "I like this", "\n", "- ", "But does it work",
-        "?", "\n", "```julia", "\n", "another code", "\n", "```", "\n", "1. ",
-        "Tester", "\n", "Third sentence ", "-", " but what happened", ".", "\n"]
+          ["Here is a code block: \n", "```julia", "\n", "code here", "\n", "```", "\n",
+        "and ", "`inline code`", ".", "\n", "Sentences here.\n", "Bullets:\n-",
+        " I like this\n-", " But does it work?\n", "```julia", "\n", "another code",
+        "\n", "```", "\n", "1. ", "Tester\n", "Third sentence -", " but what happened.\n"]
     @test join(sentences, "") == input
-    @test group_ids ==
-          [1, 2, 3, 3, 3, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-        18, 19, 20, 21, 21, 21, 21, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    @test group_ids == [
+        1, 2, 2, 2, 2, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 12, 12, 12, 13, 14, 15, 16, 17]
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -281,6 +281,13 @@ end
 end
 
 @testset "pprint" begin
+    # anything -> passthrough to show
+    x = "abc"
+    io = IOBuffer()
+    pprint(io, x)
+    output = String(take!(io))
+    @test output == "\"abc\""
+    #
     conversation = [
         PT.SystemMessage("Welcome"),
         PT.UserMessage("Hello"),
@@ -292,6 +299,15 @@ end
     output = String(take!(io))
     exp_output = "--------------------\nSystem Message\n--------------------\nWelcome\n\n--------------------\nUser Message\n--------------------\nHello\n\n--------------------\nAI Message\n--------------------\nWorld\n\n--------------------\nData Message\n--------------------\nData: Vector{Float64} (Size: (10,))\n\n"
     @test output == exp_output
+
+    struct RandomMessage1234x <: PT.AbstractMessage
+        content::String
+    end
+    msgx = RandomMessage1234x("xyz")
+    io = IOBuffer()
+    pprint(io, msgx)
+    output = String(take!(io))
+    @test occursin("\nUnknown Message\n", output)
 end
 
 @testset "auth_header" begin


### PR DESCRIPTION
- Added pretty-printing via `PT.pprint` that does NOT depend on Markdown and splits text to adjust to the width of the output terminal.
- Added support annotations for RAGTools (see `?RAGTools.Experimental.annotate_support` for more information) to highlight which parts of the generated answer come from the provided context versus the model's knowledge base. It's useful for transparency and debugging, especially in the context of AI-generated content. You can experience it if you run the output of `airag` through pretty printing (`PT.pprint`).