### PR TITLE
Fixing an issue with the API end point in the extension package of gemini + a little README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For a quick start, simply set it via `ENV["OPENAI_API_KEY"] = "your-api-key"`
 Install PromptingTools:
 ```julia
 using Pkg
-Pkg.add("PromptingTools.jl")
+Pkg.add("PromptingTools")
 ```
 
 And we're ready to go!

--- a/ext/GoogleGenAIPromptingToolsExt.jl
+++ b/ext/GoogleGenAIPromptingToolsExt.jl
@@ -11,7 +11,7 @@ function PromptingTools.ggi_generate_content(prompt_schema::PT.AbstractGoogleSch
         conversation; http_kwargs, api_kwargs...)
     ## Build the provider
     provider = GoogleGenAI.GoogleProvider(; api_key)
-    url = "$(provider.base_url)/models/$model_name:generateContent?key=$(provider.api_key)"
+    url = "$(provider.base_url)/$(provider.api_version)/models/$model_name:generateContent?key=$(provider.api_key)"
     generation_config = Dict{String, Any}()
     for (key, value) in api_kwargs
         generation_config[string(key)] = value


### PR DESCRIPTION
Hello again @svilupp,

Following-up to my previous pull request regarding the Gemini issue. If you decided to integrate GoogleGenAI.jl package, there's a minor missing part in end point that is used in GoogleGenAIPromptingToolsExt.jl.

Also, there is a little README typo that is corrected as well (could have made it in a another pull request but thought that this very minor).