### PR TITLE
Add ShareGPT template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for `aigenerate` with Anthropic API. Preset model aliases are `claudeo`, `claudes`, and `claudeh`, for Claude 3 Opus, Sonnet, and Haiku, respectively.
 - Enabled the GoogleGenAI extension since `GoogleGenAI.jl` is now officially registered. You can use `aigenerate` by setting the model to `gemini` and providing the `GOOGLE_API_KEY` environment variable.
+- Added utilities to make preparation of finetuning datasets easier. You can now export your conversations in JSONL format with ShareGPT formatting (eg, for Axolotl). See `?PT.save_conversations` for more information.
 
 ### Fixed
 
 ## [0.16.1]
 
 ### Fixed
-- Fixed a bug where `set_node_style!` was not accepting any Stylers expect for the vanilla `Styler`.
+- Fixed a bug where `set_node_style!` was not accepting any Stylers except for the vanilla `Styler`.
 
 ## [0.16.0]
 

--- a/src/PromptingTools.jl
+++ b/src/PromptingTools.jl
@@ -71,6 +71,7 @@ include("llm_ollama_managed.jl")
 include("llm_ollama.jl")
 include("llm_google.jl")
 include("llm_anthropic.jl")
+include("llm_sharegpt.jl")
 
 ## Convenience utils
 export @ai_str, @aai_str, @ai!_str, @aai!_str

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -276,7 +276,7 @@ struct AnthropicSchema <: AbstractAnthropicSchema end
     inputs::Any = nothing
 end
 
-struct AbstractShareGPTSchema <: PT.AbstractPromptSchema end
+abstract type AbstractShareGPTSchema <: AbstractPromptSchema end
 
 """
     ShareGPTSchema <: AbstractShareGPTSchema

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -276,6 +276,15 @@ struct AnthropicSchema <: AbstractAnthropicSchema end
     inputs::Any = nothing
 end
 
+struct AbstractShareGPTSchema <: PT.AbstractPromptSchema end
+
+"""
+    ShareGPTSchema <: AbstractShareGPTSchema
+
+Frequently used schema for finetuning LLMs. Conversations are recorded as a vector of dicts with keys `from` and `value` (similar to OpenAI).
+"""
+struct ShareGPTSchema <: AbstractShareGPTSchema end
+
 ## Dispatch into a default schema (can be set by Preferences.jl)
 # Since we load it as strings, we need to convert it to a symbol and instantiate it
 global PROMPT_SCHEMA::AbstractPromptSchema = @load_preference("PROMPT_SCHEMA",

--- a/src/llm_sharegpt.jl
+++ b/src/llm_sharegpt.jl
@@ -1,0 +1,38 @@
+### RENDERING
+function sharegpt_role(::AbstractMessage)
+    throw(ArgumentError("Unsupported message type $(typeof(msg))"))
+end
+sharegpt_role(::AIMessage) = "gpt"
+sharegpt_role(::UserMessage) = "human"
+sharegpt_role(::SystemMessage) = "system"
+
+function render(::AbstractShareGPTSchema, conv::AbstractVector{<:PT.AbstractMessage})
+    Dict("conversations" => [Dict("from" => sharegpt_role(msg), "value" => msg.content)
+                             for msg in conv])
+end
+
+### AI Functions
+function aigenerate(prompt_schema::AbstractShareGPTSchema, prompt::ALLOWED_PROMPT_TYPE;
+        kwargs...)
+    error("ShareGPT schema does not support aigenerate. Please use OpenAISchema instead.")
+end
+function aiembed(prompt_schema::AbstractShareGPTSchema, prompt::ALLOWED_PROMPT_TYPE;
+        kwargs...)
+    error("ShareGPT schema does not support aiembed. Please use OpenAISchema instead.")
+end
+function aiclassify(prompt_schema::AbstractShareGPTSchema, prompt::ALLOWED_PROMPT_TYPE;
+        kwargs...)
+    error("ShareGPT schema does not support aiclassify. Please use OpenAISchema instead.")
+end
+function aiextract(prompt_schema::AbstractShareGPTSchema, prompt::ALLOWED_PROMPT_TYPE;
+        kwargs...)
+    error("ShareGPT schema does not support aiextract. Please use OpenAISchema instead.")
+end
+function aiscan(prompt_schema::AbstractShareGPTSchema, prompt::ALLOWED_PROMPT_TYPE;
+        kwargs...)
+    error("ShareGPT schema does not support aiscan. Please use OpenAISchema instead.")
+end
+function aiimage(prompt_schema::AbstractShareGPTSchema, prompt::ALLOWED_PROMPT_TYPE;
+        kwargs...)
+    error("ShareGPT schema does not support aiimage. Please use OpenAISchema instead.")
+end

--- a/src/llm_sharegpt.jl
+++ b/src/llm_sharegpt.jl
@@ -6,7 +6,7 @@ sharegpt_role(::AIMessage) = "gpt"
 sharegpt_role(::UserMessage) = "human"
 sharegpt_role(::SystemMessage) = "system"
 
-function render(::AbstractShareGPTSchema, conv::AbstractVector{<:PT.AbstractMessage})
+function render(::AbstractShareGPTSchema, conv::AbstractVector{<:AbstractMessage})
     Dict("conversations" => [Dict("from" => sharegpt_role(msg), "value" => msg.content)
                              for msg in conv])
 end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -60,3 +60,43 @@ Loads a conversation (`messages`) from `io_or_file`
 function load_conversation(io_or_file::Union{IO, AbstractString})
     messages = JSON3.read(io_or_file, Vector{AbstractMessage})
 end
+
+"""
+    save_conversations(schema::AbstractPromptSchema, filename::AbstractString,
+        conversations::Vector{<:AbstractVector{<:PT.AbstractMessage}})
+
+Saves provided conversations (vector of vectors of `messages`) to `filename` rendered in the particular `schema`. 
+
+Commonly used for finetuning models with `schema = ShareGPTSchema()`
+
+The format is JSON Lines, where each line is a JSON object representing one provided conversation.
+
+See also: `save_conversation`
+
+# Examples
+```julia
+
+
+
+```
+"""
+function save_conversations(schema::AbstractPromptSchema, filename::AbstractString,
+        conversations::Vector{<:AbstractVector{<:AbstractMessage}})
+    @assert endswith(filename, ".jsonl") "Filename must end with `.jsonl` (JSON Lines format)."
+    io = IOBuffer()
+    for i in eachindex(conversations)
+        conv = conversations[i]
+        rendered_conv = render(ShareGPTSchema(), conv)
+        JSON3.write(io, rendered_conv)
+        # separate each conversation by newline
+        i < length(conversations) && print(io, "\n")
+    end
+    write(filename, String(take!(io)))
+    return nothing
+end
+
+# shortcut for ShareGPTSchema
+function save_conversations(filename::AbstractString,
+        conversations::Vector{<:AbstractVector{<:AbstractMessage}})
+    save_conversations(ShareGPTSchema(), filename, conversations)
+end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -74,10 +74,20 @@ The format is JSON Lines, where each line is a JSON object representing one prov
 See also: `save_conversation`
 
 # Examples
+
+You must always provide a VECTOR of conversations
 ```julia
+messages = AbstractMessage[SystemMessage("System message 1"),
+    UserMessage("User message"),
+    AIMessage("AI message")]
+conversation = [messages] # vector of vectors
 
+dir = tempdir()
+fn = joinpath(dir, "conversations.jsonl")
+save_conversations(fn, conversation)
 
-
+# Content of the file (one line for each conversation)
+# {"conversations":[{"value":"System message 1","from":"system"},{"value":"User message","from":"human"},{"value":"AI message","from":"gpt"}]}
 ```
 """
 function save_conversations(schema::AbstractPromptSchema, filename::AbstractString,

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -96,7 +96,7 @@ function save_conversations(schema::AbstractPromptSchema, filename::AbstractStri
     io = IOBuffer()
     for i in eachindex(conversations)
         conv = conversations[i]
-        rendered_conv = render(ShareGPTSchema(), conv)
+        rendered_conv = render(schema, conv)
         JSON3.write(io, rendered_conv)
         # separate each conversation by newline
         i < length(conversations) && print(io, "\n")

--- a/test/llm_sharegpt.jl
+++ b/test/llm_sharegpt.jl
@@ -1,0 +1,102 @@
+using PromptingTools: render, ShareGPTSchema
+using PromptingTools: AIMessage, SystemMessage, AbstractMessage
+using PromptingTools: UserMessage, UserMessageWithImages, DataMessage
+
+## @testset "render-ShareGPT" begin
+schema = ShareGPTSchema()
+# Given a schema and a vector of messages with handlebar variables, it should replace the variables with the correct values in the conversation dictionary.
+messages = [
+    SystemMessage("Act as a helpful AI assistant"),
+    UserMessage("Hello, my name is {{name}}")
+]
+expected_output = (; system = "Act as a helpful AI assistant",
+    conversation = [Dict("role" => "user", "content" => "Hello, my name is John")])
+conversation = render(schema, messages; name = "John")
+@test conversation == expected_output
+
+# AI message does NOT replace variables
+messages = [
+    SystemMessage("Act as a helpful AI assistant"),
+    AIMessage("Hello, my name is {{name}}")
+]
+expected_output = (; system = "Act as a helpful AI assistant",
+    conversation = [Dict(
+        "role" => "assistant", "content" => "Hello, my name is {{name}}")])
+conversation = render(schema, messages; name = "John")
+# AIMessage does not replace handlebar variables
+@test conversation == expected_output
+
+# Given a schema and a vector of messages with no system messages, it should add a default system prompt to the conversation dictionary.
+messages = [
+    UserMessage("User message")
+]
+conversation = render(schema, messages)
+expected_output = (; system = "Act as a helpful AI assistant",
+    conversation = [Dict("role" => "user", "content" => "User message")])
+@test conversation == expected_output
+
+# Given a schema and a vector of messages, it should return a conversation dictionary with the correct roles and contents for each message.
+messages = [
+    UserMessage("Hello"),
+    AIMessage("Hi there"),
+    UserMessage("How are you?"),
+    AIMessage("I'm doing well, thank you!")
+]
+expected_output = (; system = "Act as a helpful AI assistant",
+    conversation = [
+        Dict("role" => "user", "content" => "Hello"),
+        Dict("role" => "assistant", "content" => "Hi there"),
+        Dict("role" => "user", "content" => "How are you?"),
+        Dict("role" => "assistant", "content" => "I'm doing well, thank you!")
+    ])
+conversation = render(schema, messages)
+@test conversation == expected_output
+
+# Given a schema and a vector of messages with a system message, it should move the system to the separate slot
+messages = [
+    UserMessage("Hello"),
+    AIMessage("Hi there"),
+    SystemMessage("This is a system message")
+]
+expected_output = (; system = "This is a system message",
+    conversation = [
+        Dict("role" => "user", "content" => "Hello"),
+        Dict("role" => "assistant", "content" => "Hi there")
+    ])
+conversation = render(schema, messages)
+@test conversation == expected_output
+
+# Given an empty vector of messages, it throws an error.
+messages = AbstractMessage[]
+@test_throws AssertionError render(schema, messages)
+
+# Given a schema and a vector of messages with an unknown message type, it should skip the message and continue building the conversation dictionary.
+messages = [
+    UserMessage("Hello"),
+    DataMessage(; content = ones(3, 3)),
+    AIMessage("Hi there")
+]
+expected_output = (; system = "Act as a helpful AI assistant",
+    conversation = [
+        Dict("role" => "user", "content" => "Hello"),
+        Dict("role" => "assistant", "content" => "Hi there")
+    ])
+conversation = render(schema, messages)
+@test conversation == expected_output
+
+# Test UserMessageWithImages -- errors for now
+messages = [
+    SystemMessage("System message 1"),
+    UserMessageWithImages("User message"; image_url = "https://example.com/image.png")
+]
+@test_throws Exception render(schema, messages)
+## end
+
+@testset "not implemented ai* functions" begin
+    @test_throws ErrorException aigenerate(ShareGPTSchema(), "prompt")
+    @test_throws ErrorException aiembed(ShareGPTSchema(), "prompt")
+    @test_throws ErrorException aiextract(ShareGPTSchema(), "prompt")
+    @test_throws ErrorException aiclassify(ShareGPTSchema(), "prompt")
+    @test_throws ErrorException aiscan(ShareGPTSchema(), "prompt")
+    @test_throws ErrorException aiimage(ShareGPTSchema(), "prompt")
+end

--- a/test/llm_sharegpt.jl
+++ b/test/llm_sharegpt.jl
@@ -2,95 +2,35 @@ using PromptingTools: render, ShareGPTSchema
 using PromptingTools: AIMessage, SystemMessage, AbstractMessage
 using PromptingTools: UserMessage, UserMessageWithImages, DataMessage
 
-## @testset "render-ShareGPT" begin
-schema = ShareGPTSchema()
-# Given a schema and a vector of messages with handlebar variables, it should replace the variables with the correct values in the conversation dictionary.
-messages = [
-    SystemMessage("Act as a helpful AI assistant"),
-    UserMessage("Hello, my name is {{name}}")
-]
-expected_output = (; system = "Act as a helpful AI assistant",
-    conversation = [Dict("role" => "user", "content" => "Hello, my name is John")])
-conversation = render(schema, messages; name = "John")
-@test conversation == expected_output
+@testset "render-ShareGPT" begin
+    schema = ShareGPTSchema()
+    # Ignores any handlebar replacement, takes conversations as is
+    messages = [
+        SystemMessage("Act as a helpful AI assistant"),
+        UserMessage("Hello, my name is {{name}}"),
+        AIMessage("Hello, my name is {{name}}")
+    ]
+    expected_output = Dict("conversations" => [
+        Dict("value" => "Act as a helpful AI assistant", "from" => "system"),
+        Dict("value" => "Hello, my name is {{name}}", "from" => "human"),
+        Dict("value" => "Hello, my name is {{name}}", "from" => "gpt")])
+    conversation = render(schema, messages)
+    @test conversation == expected_output
 
-# AI message does NOT replace variables
-messages = [
-    SystemMessage("Act as a helpful AI assistant"),
-    AIMessage("Hello, my name is {{name}}")
-]
-expected_output = (; system = "Act as a helpful AI assistant",
-    conversation = [Dict(
-        "role" => "assistant", "content" => "Hello, my name is {{name}}")])
-conversation = render(schema, messages; name = "John")
-# AIMessage does not replace handlebar variables
-@test conversation == expected_output
+    # IT DOES NOT support any advanced message types (UserMessageWithImages, DataMessage)
+    messages = [
+        UserMessage("Hello"),
+        DataMessage(; content = ones(3, 3))
+    ]
 
-# Given a schema and a vector of messages with no system messages, it should add a default system prompt to the conversation dictionary.
-messages = [
-    UserMessage("User message")
-]
-conversation = render(schema, messages)
-expected_output = (; system = "Act as a helpful AI assistant",
-    conversation = [Dict("role" => "user", "content" => "User message")])
-@test conversation == expected_output
+    @test_throws ArgumentError render(schema, messages)
 
-# Given a schema and a vector of messages, it should return a conversation dictionary with the correct roles and contents for each message.
-messages = [
-    UserMessage("Hello"),
-    AIMessage("Hi there"),
-    UserMessage("How are you?"),
-    AIMessage("I'm doing well, thank you!")
-]
-expected_output = (; system = "Act as a helpful AI assistant",
-    conversation = [
-        Dict("role" => "user", "content" => "Hello"),
-        Dict("role" => "assistant", "content" => "Hi there"),
-        Dict("role" => "user", "content" => "How are you?"),
-        Dict("role" => "assistant", "content" => "I'm doing well, thank you!")
-    ])
-conversation = render(schema, messages)
-@test conversation == expected_output
-
-# Given a schema and a vector of messages with a system message, it should move the system to the separate slot
-messages = [
-    UserMessage("Hello"),
-    AIMessage("Hi there"),
-    SystemMessage("This is a system message")
-]
-expected_output = (; system = "This is a system message",
-    conversation = [
-        Dict("role" => "user", "content" => "Hello"),
-        Dict("role" => "assistant", "content" => "Hi there")
-    ])
-conversation = render(schema, messages)
-@test conversation == expected_output
-
-# Given an empty vector of messages, it throws an error.
-messages = AbstractMessage[]
-@test_throws AssertionError render(schema, messages)
-
-# Given a schema and a vector of messages with an unknown message type, it should skip the message and continue building the conversation dictionary.
-messages = [
-    UserMessage("Hello"),
-    DataMessage(; content = ones(3, 3)),
-    AIMessage("Hi there")
-]
-expected_output = (; system = "Act as a helpful AI assistant",
-    conversation = [
-        Dict("role" => "user", "content" => "Hello"),
-        Dict("role" => "assistant", "content" => "Hi there")
-    ])
-conversation = render(schema, messages)
-@test conversation == expected_output
-
-# Test UserMessageWithImages -- errors for now
-messages = [
-    SystemMessage("System message 1"),
-    UserMessageWithImages("User message"; image_url = "https://example.com/image.png")
-]
-@test_throws Exception render(schema, messages)
-## end
+    messages = [
+        SystemMessage("System message 1"),
+        UserMessageWithImages("User message"; image_url = "https://example.com/image.png")
+    ]
+    @test_throws ArgumentError render(schema, messages)
+end
 
 @testset "not implemented ai* functions" begin
     @test_throws ErrorException aigenerate(ShareGPTSchema(), "prompt")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ end
     include("llm_ollama.jl")
     include("llm_google.jl")
     include("llm_anthropic.jl")
+    include("llm_sharegpt.jl")
     include("macros.jl")
     include("templates.jl")
     include("serialization.jl")

--- a/test/serialization.jl
+++ b/test/serialization.jl
@@ -1,6 +1,7 @@
 using PromptingTools: AIMessage,
-    SystemMessage, UserMessage, UserMessageWithImages, AbstractMessage, DataMessage
-using PromptingTools: save_conversation, load_conversation
+                      SystemMessage, UserMessage, UserMessageWithImages, AbstractMessage,
+                      DataMessage, ShareGPTSchema
+using PromptingTools: save_conversation, load_conversation, save_conversations
 using PromptingTools: save_template, load_template
 
 @testset "Serialization - Messages" begin
@@ -23,7 +24,7 @@ end
     version = "1.1"
     msgs = [
         SystemMessage("You are an impartial AI judge evaluting whether the provided statement is \"true\" or \"false\". Answer \"unknown\" if you cannot decide."),
-        UserMessage("# Statement\n\n{{it}}"),
+        UserMessage("# Statement\n\n{{it}}")
     ]
     tmp, _ = mktemp()
     save_template(tmp,
@@ -36,3 +37,15 @@ end
     @test metadata[1].content == "Template Metadata"
     @test metadata[1].source == ""
 end
+
+## @testset "Serialization - Messages" begin
+# Test save_conversations
+messages = AbstractMessage[SystemMessage("System message 1"),
+    UserMessage("User message"),
+    AIMessage("AI message")]
+tmp, _ = mktemp()
+save_conversations(tmp, [messages])
+# Test load_conversation
+loaded_messages = load_conversation(tmp)
+@test loaded_messages == messages
+## end

--- a/test/serialization.jl
+++ b/test/serialization.jl
@@ -38,14 +38,15 @@ end
     @test metadata[1].source == ""
 end
 
-## @testset "Serialization - Messages" begin
-# Test save_conversations
-messages = AbstractMessage[SystemMessage("System message 1"),
-    UserMessage("User message"),
-    AIMessage("AI message")]
-tmp, _ = mktemp()
-save_conversations(tmp, [messages])
-# Test load_conversation
-loaded_messages = load_conversation(tmp)
-@test loaded_messages == messages
-## end
+@testset "Serialization - Messages" begin
+    # Test save_conversations
+    messages = AbstractMessage[SystemMessage("System message 1"),
+        UserMessage("User message"),
+        AIMessage("AI message")]
+    dir = tempdir()
+    fn = joinpath(dir, "conversations.jsonl")
+    save_conversations(fn, [messages])
+    s = read(fn, String)
+    @test s ==
+          """{"conversations":[{"value":"System message 1","from":"system"},{"value":"User message","from":"human"},{"value":"AI message","from":"gpt"}]}"""
+end


### PR DESCRIPTION
- Added utilities to make preparation of finetuning datasets easier. You can now export your conversations in JSONL format with ShareGPT formatting (eg, for Axolotl). See `?PT.save_conversations` for more information.
