### PR TITLE
Add data extraction for Anthropic models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds support for binary embeddings in RAGTools (dispatch type for `find_closest` is `finder=BinaryCosineSimilarity()`), but you can also just convert the embeddings to binary yourself (always choose `Matrix{Bool}` for speed, not `BitMatrix`) and use without any changes (very little performance difference at the moment).
 - Added Ollama embedding models to the model registry ("nomic-embed-text", "mxbai-embed-large") and versioned MistralAI models.
 - Added template for data extraction with Chain-of-thought reasoning: `:ExtractDataCoTXML`.
-- Added data extraction support for Anthropic models (Claude 3) with `aiextract`. Try it with Claude-3 Haiku (`model="claudeh"`) and Chain-of-though template (`:ExtractDataCoTXML`) - see `?aiextract` for more information.
+- Added data extraction support for Anthropic models (Claude 3) with `aiextract`. Try it with Claude-3 Haiku (`model="claudeh"`) and Chain-of-though template (`:ExtractDataCoTXML`) - see `?aiextract` for more information and check Anthropic's [recommended practices](https://docs.anthropic.com/claude/docs/tool-use).
 
 ## [0.17.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds support for binary embeddings in RAGTools (dispatch type for `find_closest` is `finder=BinaryCosineSimilarity()`), but you can also just convert the embeddings to binary yourself (always choose `Matrix{Bool}` for speed, not `BitMatrix`) and use without any changes (very little performance difference at the moment).
 - Added Ollama embedding models to the model registry ("nomic-embed-text", "mxbai-embed-large") and versioned MistralAI models.
 - Added template for data extraction with Chain-of-thought reasoning: `:ExtractDataCoTXML`.
-- Added data extraction support for Anthropic models (Claude 3) with `aiextract`. Try it with Claude-3 Haiku (`model="claudeh"`) and Chain-of-though template (`:ExtractDataCoTXML`) - see `?aiextract` for more information and check Anthropic's [recommended practices](https://docs.anthropic.com/claude/docs/tool-use).
+- Added data extraction support for Anthropic models (Claude 3) with `aiextract`. Try it with Claude-3 Haiku (`model="claudeh"`) and Chain-of-though template (`:ExtractDataCoTXML`). See `?aiextract` for more information and check Anthropic's [recommended practices](https://docs.anthropic.com/claude/docs/tool-use).
 
 ## [0.17.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Adds support for binary embeddings in RAGTools (dispatch type for `find_closest` is `finder=BinaryCosineSimilarity()`), but you can also just convert the embeddings to binary yourself (always choose `Matrix{Bool}` for speed, not `BitMatrix`) and use without any changes (very little performance difference at the moment).
-- Added Ollama embedding models to the model registry ("nomic-embed-text", "mxbai-embed-large") and versioned MistralAI models.
 
 ### Fixed
+
+## [0.18.0]
+
+### Added
+- Adds support for binary embeddings in RAGTools (dispatch type for `find_closest` is `finder=BinaryCosineSimilarity()`), but you can also just convert the embeddings to binary yourself (always choose `Matrix{Bool}` for speed, not `BitMatrix`) and use without any changes (very little performance difference at the moment).
+- Added Ollama embedding models to the model registry ("nomic-embed-text", "mxbai-embed-large") and versioned MistralAI models.
+- Added template for data extraction with Chain-of-thought reasoning: `:ExtractDataCoTXML`.
+- Added data extraction support for Anthropic models (Claude 3) with `aiextract`. Try it with Claude-3 Haiku (`model="claudeh"`) and Chain-of-though template (`:ExtractDataCoTXML`) - see `?aiextract` for more information.
 
 ## [0.17.1]
 

--- a/src/llm_anthropic.jl
+++ b/src/llm_anthropic.jl
@@ -8,16 +8,19 @@
     render(schema::AbstractAnthropicSchema,
         messages::Vector{<:AbstractMessage};
         conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        tools::Vector{<:Dict{String, <:Any}} = Dict{String, Any}[],
         kwargs...)
 
 Builds a history of the conversation to provide the prompt to the API. All unspecified kwargs are passed as replacements such that `{{key}}=>value` in the template.
 
 # Keyword Arguments
 - `conversation`: Past conversation to be included in the beginning of the prompt (for continued conversations).
+- `tools`: A list of tools to be used in the conversation. Added to the end of the system prompt to enforce its use.
 """
 function render(schema::AbstractAnthropicSchema,
         messages::Vector{<:AbstractMessage};
         conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        tools::Vector{<:Dict{String, <:Any}} = Dict{String, Any}[],
         kwargs...)
     ## 
     @assert count(issystemmessage, messages)<=1 "AbstractAnthropicSchema only supports at most 1 System message"
@@ -47,6 +50,19 @@ function render(schema::AbstractAnthropicSchema,
         end
         # Note: Ignores any DataMessage or other types
     end
+
+    ## Add Tool definitions to the System Prompt
+    if !isempty(tools)
+        length(tools) > 1 && @warn "Multiple tools provided. Using the first one only."
+        ANTHROPIC_TOOL_SUFFIX = "Use the $(tools[1]["name"]) tool in your response."
+        ## Add to system message
+        if isnothing(system)
+            system = ANTHROPIC_TOOL_SUFFIX
+        else
+            system *= "\n\n" * ANTHROPIC_TOOL_SUFFIX
+        end
+    end
+
     ## Sense check
     @assert !isempty(conversation) "AbstractAnthropicSchema requires at least 1 User message, ie, no `prompt` provided!"
 
@@ -101,7 +117,8 @@ function anthropic_api(
     ## 
     headers = auth_header(
         api_key; bearer = false, x_api_key = true,
-        extra_headers = ["anthropic-version" => "2023-06-01"])
+        extra_headers = ["anthropic-version" => "2023-06-01",
+            "anthropic-beta" => "tools-2024-04-04"])
     api_url = string(url, "/", endpoint)
     resp = HTTP.post(api_url, headers, JSON3.write(body); http_kwargs...)
     body = JSON3.read(resp.body)
@@ -244,6 +261,211 @@ function aigenerate(
     return output
 end
 
+"""
+    aiextract(prompt_schema::AbstractAnthropicSchema, prompt::ALLOWED_PROMPT_TYPE;
+        return_type::Type,
+        verbose::Bool = true,
+        api_key::String = ANTHROPIC_API_KEY,
+        model::String = MODEL_CHAT,
+        return_all::Bool = false, dry_run::Bool = false,
+        conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        http_kwargs::NamedTuple = (retry_non_idempotent = true,
+            retries = 5,
+            readtimeout = 120), api_kwargs::NamedTuple = NamedTuple(),
+        kwargs...)
+
+Extract required information (defined by a struct **`return_type`**) from the provided prompt by leveraging Anthropic's function calling mode.
+
+This is a perfect solution for extracting structured information from text (eg, extract organization names in news articles, etc.).
+
+Read best practics [here](https://docs.anthropic.com/claude/docs/tool-use#tool-use-best-practices-and-limitations).
+
+It's effectively a light wrapper around `aigenerate` call, which requires additional keyword argument `return_type` to be provided
+ and will enforce the model outputs to adhere to it.
+
+# Arguments
+- `prompt_schema`: An optional object to specify which prompt template should be applied (Default to `PROMPT_SCHEMA = OpenAISchema`)
+- `prompt`: Can be a string representing the prompt for the AI conversation, a `UserMessage`, a vector of `AbstractMessage` or an `AITemplate`
+- `return_type`: A **struct** TYPE representing the the information we want to extract. Do not provide a struct instance, only the type.
+  If the struct has a docstring, it will be provided to the model as well. It's used to enforce structured model outputs or provide more information.
+- `verbose`: A boolean indicating whether to print additional information.
+- `api_key`: A string representing the API key for accessing the OpenAI API.
+- `model`: A string representing the model to use for generating the response. Can be an alias corresponding to a model ID defined in `MODEL_ALIASES`.
+- `return_all::Bool=false`: If `true`, returns the entire conversation history, otherwise returns only the last message (the `AIMessage`).
+- `dry_run::Bool=false`: If `true`, skips sending the messages to the model (for debugging, often used with `return_all=true`).
+- `conversation`: An optional vector of `AbstractMessage` objects representing the conversation history. If not provided, it is initialized as an empty vector.
+- `http_kwargs`: A named tuple of HTTP keyword arguments.
+- `api_kwargs`: A named tuple of API keyword arguments. 
+- `kwargs`: Prompt variables to be used to fill the prompt/template
+
+# Returns
+If `return_all=false` (default):
+- `msg`: An `DataMessage` object representing the extracted data, including the content, status, tokens, and elapsed time. 
+  Use `msg.content` to access the extracted data.
+
+If `return_all=true`:
+- `conversation`: A vector of `AbstractMessage` objects representing the full conversation history, including the response from the AI model (`DataMessage`).
+
+
+See also: `function_call_signature`, `MaybeExtract`, `ItemsExtract`, `aigenerate`
+
+# Example
+
+Do you want to extract some specific measurements from a text like age, weight and height?
+You need to define the information you need as a struct (`return_type`):
+```
+"Person's age, height, and weight."
+struct MyMeasurement
+    age::Int # required
+    height::Union{Int,Nothing} # optional
+    weight::Union{Nothing,Float64} # optional
+end
+msg = aiextract("James is 30, weighs 80kg. He's 180cm tall."; model="claudeh", return_type=MyMeasurement)
+# PromptingTools.DataMessage(MyMeasurement)
+msg.content
+# MyMeasurement(30, 180, 80.0)
+```
+
+The fields that allow `Nothing` are marked as optional in the schema:
+```
+msg = aiextract("James is 30."; model="claudeh", return_type=MyMeasurement)
+# MyMeasurement(30, nothing, nothing)
+```
+
+If there are multiple items you want to extract, define a wrapper struct to get a Vector of `MyMeasurement`:
+```
+struct ManyMeasurements
+    measurements::Vector{MyMeasurement}
+end
+
+msg = aiextract("James is 30, weighs 80kg. He's 180cm tall. Then Jack is 19 but really tall - over 190!"; model="claudeh", return_type=ManyMeasurements)
+
+msg.content.measurements
+# 2-element Vector{MyMeasurement}:
+#  MyMeasurement(30, 180, 80.0)
+#  MyMeasurement(19, 190, nothing)
+```
+
+Or you can use the convenience wrapper `ItemsExtract` to extract multiple measurements (zero, one or more):
+```julia
+using PromptingTools: ItemsExtract
+
+return_type = ItemsExtract{MyMeasurement}
+msg = aiextract("James is 30, weighs 80kg. He's 180cm tall. Then Jack is 19 but really tall - over 190!"; model="claudeh", return_type)
+
+msg.content.items # see the extracted items
+```
+
+Or if you want your extraction to fail gracefully when data isn't found, use `MaybeExtract{T}` wrapper
+ (this trick is inspired by the Instructor package!):
+```
+using PromptingTools: MaybeExtract
+
+return_type = MaybeExtract{MyMeasurement}
+# Effectively the same as:
+# struct MaybeExtract{T}
+#     result::Union{T, Nothing} // The result of the extraction
+#     error::Bool // true if a result is found, false otherwise
+#     message::Union{Nothing, String} // Only present if no result is found, should be short and concise
+# end
+
+# If LLM extraction fails, it will return a Dict with `error` and `message` fields instead of the result!
+msg = aiextract("Extract measurements from the text: I am giraffe"; model="claudeo", return_type)
+msg.content
+# Output: MaybeExtract{MyMeasurement}(nothing, true, "I'm sorry, but your input of \"I am giraffe\" does not contain any information about a person's age, height or weight measurements that I can extract. To use this tool, please provide a statement that includes at least the person's age, and optionally their height in inches and weight in pounds. Without that information, I am unable to extract the requested measurements.")
+```
+That way, you can handle the error gracefully and get a reason why extraction failed (in `msg.content.message`).
+
+However, this can fail with weaker models like `claudeh`, so we can apply some of our prompt templates with embedding reasoning step:
+```julia
+msg = aiextract(:ExtractDataCoTXML; data="I am giraffe", model="claudeh", return_type)
+msg.content
+# Output: MaybeExtract{MyMeasurement}(nothing, true, "The provided data does not contain the expected information about a person's age, height, and weight.")
+```
+Note that when using a prompt template, we provide `data` for the extraction as the corresponding placeholder (see `aitemplates("extract")` for documentation of this template).
+
+Note that the error message refers to a giraffe not being a human, 
+ because in our `MyMeasurement` docstring, we said that it's for people!
+```
+"""
+function aiextract(prompt_schema::AbstractAnthropicSchema, prompt::ALLOWED_PROMPT_TYPE;
+        return_type::Type,
+        verbose::Bool = true,
+        api_key::String = ANTHROPIC_API_KEY,
+        model::String = MODEL_CHAT,
+        return_all::Bool = false, dry_run::Bool = false,
+        conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        http_kwargs::NamedTuple = (retry_non_idempotent = true,
+            retries = 5,
+            readtimeout = 120), api_kwargs::NamedTuple = NamedTuple(),
+        kwargs...)
+    ##
+    global MODEL_ALIASES
+
+    ## Find the unique ID for the model alias provided
+    model_id = get(MODEL_ALIASES, model, model)
+
+    ## Tools definition
+    sig = function_call_signature(return_type; max_description_length = 100)
+    tools = [Dict("name" => sig["name"], "description" => get(sig, "description", ""),
+        "input_schema" => sig["parameters"])]
+
+    ## Add the function call stopping sequence to the api_kwargs
+    api_kwargs = merge(api_kwargs, (; tools))
+
+    ## We provide the tool description to the rendering engine
+    conv_rendered = render(prompt_schema, prompt; tools, conversation, kwargs...)
+
+    if !dry_run
+        time = @elapsed resp = anthropic_api(
+            prompt_schema, conv_rendered.conversation; api_key,
+            conv_rendered.system, endpoint = "messages", model = model_id, http_kwargs,
+            api_kwargs...)
+        tokens_prompt = get(resp.response[:usage], :input_tokens, 0)
+        tokens_completion = get(resp.response[:usage], :output_tokens, 0)
+        finish_reason = get(resp.response, :stop_reason, nothing)
+        content = if finish_reason == "tool_use"
+            contents = filter(x -> x[:type] == "tool_use", resp.response[:content])
+            length(contents) > 1 &&
+                @warn "Multiple tool_use found in the response. Using the first one."
+            ## parse it into object
+            arguments = JSON3.write(contents[1][:input])
+            try
+                JSON3.read(arguments, return_type)
+            catch e
+                @warn "There was an error parsing the response: $e. Using the raw response instead."
+                JSON3.read(arguments) |> copy
+            end
+        else
+            ## fallback, return text
+            @warn "No tool_use found in the response. Returning the raw text instead."
+            mapreduce(x -> get(x, :text, ""), *, resp.response[:content]) |> strip
+        end
+        ## Build data message
+        msg = DataMessage(; content,
+            status = Int(resp.status),
+            cost = call_cost(tokens_prompt, tokens_completion, model_id),
+            finish_reason,
+            tokens = (tokens_prompt, tokens_completion),
+            elapsed = time)
+
+        ## Reporting
+        verbose && @info _report_stats(msg, model_id)
+    else
+        msg = nothing
+    end
+    ## Select what to return
+    output = finalize_outputs(prompt,
+        conv_rendered,
+        msg;
+        conversation,
+        return_all,
+        dry_run,
+        kwargs...)
+
+    return output
+end
+
 function aiembed(prompt_schema::AbstractAnthropicSchema, prompt::ALLOWED_PROMPT_TYPE;
         kwargs...)
     error("Anthropic schema does not yet support aiembed. Please use OpenAISchema instead.")
@@ -251,10 +473,6 @@ end
 function aiclassify(prompt_schema::AbstractAnthropicSchema, prompt::ALLOWED_PROMPT_TYPE;
         kwargs...)
     error("Anthropic schema does not yet support aiclassify. Please use OpenAISchema instead.")
-end
-function aiextract(prompt_schema::AbstractAnthropicSchema, prompt::ALLOWED_PROMPT_TYPE;
-        kwargs...)
-    error("Anthropic schema does not yet support aiextract. Please use OpenAISchema instead.")
 end
 function aiscan(prompt_schema::AbstractAnthropicSchema, prompt::ALLOWED_PROMPT_TYPE;
         kwargs...)

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -981,7 +981,7 @@ msg = aiextract("James is 30."; return_type=MyMeasurement)
 
 If there are multiple items you want to extract, define a wrapper struct to get a Vector of `MyMeasurement`:
 ```
-struct MyMeasurementWrapper
+struct ManyMeasurements
     measurements::Vector{MyMeasurement}
 end
 
@@ -1008,7 +1008,7 @@ Or if you want your extraction to fail gracefully when data isn't found, use `Ma
 ```
 using PromptingTools: MaybeExtract
 
-type = MaybeExtract{MyMeasurement}
+return_type = MaybeExtract{MyMeasurement}
 # Effectively the same as:
 # struct MaybeExtract{T}
 #     result::Union{T, Nothing} // The result of the extraction
@@ -1017,7 +1017,7 @@ type = MaybeExtract{MyMeasurement}
 # end
 
 # If LLM extraction fails, it will return a Dict with `error` and `message` fields instead of the result!
-msg = aiextract("Extract measurements from the text: I am giraffe", type)
+msg = aiextract("Extract measurements from the text: I am giraffe"; return_type)
 msg.content
 # MaybeExtract{MyMeasurement}(nothing, true, "I'm sorry, but I can only assist with human measurements.")
 ```

--- a/templates/extraction/xml-formatted/ExtractDataCoTXML.json
+++ b/templates/extraction/xml-formatted/ExtractDataCoTXML.json
@@ -1,0 +1,21 @@
+[
+    {
+        "content": "Template Metadata",
+        "description": "Template suitable for data extraction via `aiextract` calls with Chain-of-thought reasoning. The prompt is XML-formatted - useful for Anthropic models and it forces the model to apply reasoning first, before picking the right tool. Placeholder: `data`.",
+        "version": "1.0",
+        "source": "",
+        "_type": "metadatamessage"
+    },
+    {
+        "content": "You are a world-class expert for tool-calling and data extraction. Analyze the user-provided data in tags <data></data> meticulously, extract key information as structured output, and format these details as arguments for a specific tool call. Ensure strict adherence to user instructions, particularly those regarding argument style and formatting as outlined in the tool's description, prioritizing detail orientation and accuracy in alignment with the user's explicit requirements. Before answering, explain your reasoning step-by-step in tags.",
+        "variables": [],
+        "_type": "systemmessage"
+    },
+    {
+        "content": "<data>\n{{data}}\n</data>",
+        "variables": [
+            "data"
+        ],
+        "_type": "usermessage"
+    }
+]


### PR DESCRIPTION
- Added template for data extraction with Chain-of-thought reasoning: `:ExtractDataCoTXML`.
- Added data extraction support for Anthropic models (Claude 3) with `aiextract`. Try it with Claude-3 Haiku (`model="claudeh"`) and Chain-of-though template (`:ExtractDataCoTXML`). See `?aiextract` for more information and check Anthropic's [recommended practices](https://docs.anthropic.com/claude/docs/tool-use).
