### PR TITLE
Add Llama 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.21.0]
+
+### Added
+- New models added to the model registry: Llama3 8b on Ollama (alias "llama3" for convenience) and on Together.ai (alias "tllama3", "t" stands for Together.ai), also adding the llama3 70b on Together.ai (alias "tllama370") and the powerful Mixtral-8x22b on Together.ai (alias "tmixtral22").
+
+### Fixed
+- Fixed a bug where pretty-printing `RAGResult` would forget a newline between the sources and context sections.
+
 ## [0.20.1]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.20.1"
+version = "0.21.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/Experimental/RAGTools/annotation.jl
+++ b/src/Experimental/RAGTools/annotation.jl
@@ -100,14 +100,16 @@ end
 
 """
     PromptingTools.pprint(
-        io::IO, node::AbstractAnnotatedNode; text_width::Int = displaysize(io)[2])
+        io::IO, node::AbstractAnnotatedNode;
+        text_width::Int = displaysize(io)[2], add_newline::Bool = true)
 
 Pretty print the `node` to the `io` stream, including all its children
 
 Supports only `node.style::Styler` for now.
 """
 function PromptingTools.pprint(
-        io::IO, node::AbstractAnnotatedNode; text_width::Int = displaysize(io)[2])
+        io::IO, node::AbstractAnnotatedNode;
+        text_width::Int = displaysize(io)[2], add_newline::Bool = true)
     for node in AbstractTrees.PreOrderDFS(node)
         ## print out text only for leaf nodes (ie, with no children)
         if isempty(node.children) && node.style isa Styler
@@ -125,12 +127,14 @@ function PromptingTools.pprint(
             print(io, node.content)
         end
     end
+    # finish with a new line
+    add_newline && print(io, "\n")
     return nothing
 end
 
 function PromptingTools.pprint(
-        node::AbstractAnnotatedNode; text_width::Int = displaysize(stdout)[2])
-    pprint(stdout, node; text_width)
+        node::AbstractAnnotatedNode; text_width::Int = displaysize(stdout)[2], add_newline::Bool = true)
+    pprint(stdout, node; text_width, add_newline)
 end
 
 ### ANNOTATION METHODS -- TrigramAnnotater

--- a/src/Experimental/RAGTools/types.jl
+++ b/src/Experimental/RAGTools/types.jl
@@ -481,11 +481,11 @@ function PT.pprint(
         pprint(io, root; text_width)
     end
     if add_context
-        print(io, "-"^20, "\n")
+        print(io, "\n" * "-"^20, "\n")
         printstyled(io, "CONTEXT", color = :blue, bold = true)
         print(io, "\n", "-"^20, "\n")
         for (i, ctx) in enumerate(r.context)
-            print(io, "$(i). ", PT.wrap_string(ctx, text_width))
+            print(io, PT.wrap_string(ctx, text_width))
             print(io, "\n", "-"^20, "\n")
         end
     end

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -298,6 +298,9 @@ aliases = merge(
         "yi34c" => "yi:34b-chat",
         "oh25" => "openhermes2.5-mistral",
         "starling" => "starling-lm",
+        "llama3" => "llama3:8b-instruct-q5_K_S",
+        # o-llama3, because it's hosted on Ollama (same as t-mixtral on Together)
+        "ollama3" => "llama3:8b-instruct-q5_K_S",
         "local" => "local-server",
         "gemini" => "gemini-pro",
         ## f-mixtral -> Fireworks.ai Mixtral
@@ -305,6 +308,9 @@ aliases = merge(
         "firefunction" => "accounts/fireworks/models/firefunction-v1",
         ## t-mixtral -> Together.ai Mixtral
         "tmixtral" => "mistralai/Mixtral-8x7B-Instruct-v0.1",
+        "tmixtral22" => "mistralai/Mixtral-8x22B-Instruct-v0.1",
+        "tllama3" => "meta-llama/Llama-3-8b-chat-hf",
+        "tllama370" => "meta-llama/Llama-3-70b-chat-hf",
         ## Mistral AI
         "mistral-tiny" => "mistral-tiny",
         "mistral-small" => "mistral-small-latest",
@@ -418,6 +424,17 @@ registry = Dict{String, ModelSpec}(
         0.0,
         0.0,
         "Yi is a 34B parameter model finetuned by X on top of base model from Starling AI."),
+    "llama3:8b-instruct-q5_K_S" => ModelSpec("llama3:8b-instruct-q5_K_S",
+        OllamaSchema(),
+        0.0,
+        0.0,
+        "Llama 3 8b is the latest model from Meta"
+    ),
+    "wizardlm2:7b-q5_K_S" => ModelSpec("wizardlm2:7b-q5_K_S",
+        OllamaSchema(),
+        0.0,
+        0.0,
+        "WizardLM2 7b from Microsoft."),
     "nomic-embed-text" => ModelSpec("nomic-embed-text",
         OllamaSchema(),
         0.0,
@@ -550,12 +567,31 @@ registry = Dict{String, ModelSpec}(
         0.0, #unknown, expected to be the same as Mixtral
         0.0, #unknown, expected to be the same as Mixtral
         "Fireworks' open-source function calling model (fine-tuned Mixtral). Useful for `aiextract` calls. For more information, see [models](https://fireworks.ai/models/fireworks/firefunction-v1)."),
+    ## Together AI
     "mistralai/Mixtral-8x7B-Instruct-v0.1" => ModelSpec(
         "mistralai/Mixtral-8x7B-Instruct-v0.1",
         TogetherOpenAISchema(),
         6e-7,
         6e-7,
         "Mixtral (8x7b) from Mistral, hosted by Together.ai. For more information, see [models](https://docs.together.ai/docs/inference-models)."),
+    "mistralai/Mixtral-8x22B-Instruct-v0.1" => ModelSpec(
+        "mistralai/Mixtral-8x22B-Instruct-v0.1",
+        TogetherOpenAISchema(),
+        1.2e-6,
+        1.2e-6,
+        "Mixtral (22x7b) from Mistral, hosted by Together.ai. For more information, see [models](https://docs.together.ai/docs/inference-models)."),
+    "meta-llama/Llama-3-8b-chat-hf" => ModelSpec(
+        "meta-llama/Llama-3-8b-chat-hf",
+        TogetherOpenAISchema(),
+        2e-7,
+        2e-7,
+        "Meta Llama3 8b from Mistral, hosted by Together.ai. For more information, see [models](https://docs.together.ai/docs/inference-models)."),
+    "meta-llama/Llama-3-70b-chat-hf" => ModelSpec(
+        "meta-llama/Llama-3-70b-chat-hf",
+        TogetherOpenAISchema(),
+        9e-7,
+        9e-7,
+        "Meta Llama3 70b from Mistral, hosted by Together.ai. For more information, see [models](https://docs.together.ai/docs/inference-models)."),
     ### Anthropic models
     "claude-3-opus-20240229" => ModelSpec("claude-3-opus-20240229",
         AnthropicSchema(),

--- a/test/Experimental/RAGTools/annotation.jl
+++ b/test/Experimental/RAGTools/annotation.jl
@@ -55,7 +55,7 @@ end
     # Test pprint function for a single node
     node = AnnotatedNode(content = "test", group_id = 123)
     io = IOBuffer()
-    pprint(io, node)
+    pprint(io, node; add_newline = false)
     @test String(take!(io)) == "test"
 
     ## Multiple nodes
@@ -65,7 +65,7 @@ end
     child_node2 = AnnotatedNode(parent = parent_node, content = "child2")
     push!(parent_node.children, child_node2)
     io = IOBuffer()
-    pprint(io, parent_node)
+    pprint(io, parent_node; add_newline = false)
     output = String(take!(io))
     # iterate over all nodes with no children
     @test output == "childchild2"
@@ -76,7 +76,7 @@ end
     io = IOBuffer()
     pprint(io, parent_node)
     output = String(take!(io))
-    @test output == "childchild3"
+    @test output == "childchild3\n"
 end
 
 @testset "set_node_style!" begin
@@ -314,7 +314,7 @@ end
     # no scores, so no extra children
     @test length(annotated_root.children) == 3
     io = IOBuffer()
-    pprint(io, annotated_root)
+    pprint(io, annotated_root; add_newline = false)
     output = String(take!(io))
     @test answer == output
 
@@ -340,7 +340,7 @@ end
             "Source 1", "Source 2", "Source 3"])
     annotated_root = annotate_support(annotater, r)
     io = IOBuffer()
-    pprint(io, annotated_root)
+    pprint(io, annotated_root; add_newline = false)
     output = String(take!(io))
     @test occursin("This is a test answer.", output)
     @test occursin("[1,0.67]", output)

--- a/test/Experimental/RAGTools/generation.jl
+++ b/test/Experimental/RAGTools/generation.jl
@@ -1,3 +1,4 @@
+using PromptingTools: TestEchoOpenAISchema
 using PromptingTools.Experimental.RAGTools: ChunkIndex,
                                             CandidateChunks, build_context, build_context!
 using PromptingTools.Experimental.RAGTools: MaybeTags, Tag, ContextEnumerator,
@@ -197,7 +198,7 @@ end
 
 @testset "airag" begin
     # test with a mock server
-    PORT = rand(20010:40001)
+    PORT = rand(10000:40002)
     PT.register_model!(; name = "mock-emb", schema = PT.CustomOpenAISchema())
     PT.register_model!(; name = "mock-meta", schema = PT.CustomOpenAISchema())
     PT.register_model!(; name = "mock-gen", schema = PT.CustomOpenAISchema())
@@ -300,9 +301,9 @@ end
 
     ## Pretty printing
     io = IOBuffer()
-    PT.pprint(io, result; add_newline = false)
+    PT.pprint(io, result)
     result_str = String(take!(io))
-    expected_str = "--------------------\nQUESTION(s)\n--------------------\n- Time?\n\n--------------------\nANSWER\n--------------------\n# Question\n\nTime\n\n\n\n# Answer\n\n--------------------\nSOURCES\n--------------------\n1. .\n2. .\n3. ."
+    expected_str = "--------------------\nQUESTION(s)\n--------------------\n- Time?\n\n--------------------\nANSWER\n--------------------\n# Question\n\nTime\n\n\n\n# Answer\n\n--------------------\nSOURCES\n--------------------\n1. .\n2. .\n3. .\n"
     @test result_str == expected_str
 
     # clean up

--- a/test/Experimental/RAGTools/generation.jl
+++ b/test/Experimental/RAGTools/generation.jl
@@ -300,7 +300,7 @@ end
 
     ## Pretty printing
     io = IOBuffer()
-    PT.pprint(io, result)
+    PT.pprint(io, result; add_newline = false)
     result_str = String(take!(io))
     expected_str = "--------------------\nQUESTION(s)\n--------------------\n- Time?\n\n--------------------\nANSWER\n--------------------\n# Question\n\nTime\n\n\n\n# Answer\n\n--------------------\nSOURCES\n--------------------\n1. .\n2. .\n3. ."
     @test result_str == expected_str


### PR DESCRIPTION
- New models added to the model registry: Llama3 8b on Ollama (alias "llama3" for convenience) and on Together.ai (alias "tllama3", "t" stands for Together.ai), also adding the llama3 70b on Together.ai (alias "tllama370") and the powerful Mixtral-8x22b on Together.ai (alias "tmixtral22").
- Fixed a bug where pretty-printing `RAGResult` would forget a newline between the sources and context sections.