### PR TITLE
Add support for groq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.22.0]
+
+### Added
+- Added support for [Groq](https://console.groq.com/), the fastest LLM provider out there. It's free for now, so you can try it out - you just need to set your `GROQ_API_KEY`. We've added Llama3 8b (alias "gllama3"), 70b (alias "gllama370") and Mixtral 8x7b (alias "gmixtral"). For the shortcut junkies, we also added a shorthand Llama3 8b = "gl3" (first two letters and the last digit), Llama3 70b = "gl70" (first two letters and the last two digits).
+
 ## [0.21.0]
 
 ### Added

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -177,6 +177,21 @@ Requires one environment variables to be set:
 """
 struct TogetherOpenAISchema <: AbstractOpenAISchema end
 
+"""
+    GroqOpenAISchema
+
+Schema to call the [groq.com](https://console.groq.com/keys) API.
+
+Links:
+- [Get your API key](https://console.groq.com/keys)
+- [API Reference](https://console.groq.com/docs/quickstart)
+- [Available models](https://console.groq.com/docs/models)
+
+Requires one environment variables to be set:
+- `GROQ_API_KEY`: Your API key (often starts with "gsk_...")
+"""
+struct GroqOpenAISchema <: AbstractOpenAISchema end
+
 abstract type AbstractOllamaSchema <: AbstractPromptSchema end
 
 """

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -192,6 +192,19 @@ function OpenAI.create_chat(schema::TogetherOpenAISchema,
         base_url = url)
     OpenAI.create_chat(provider, model, conversation; kwargs...)
 end
+function OpenAI.create_chat(schema::GroqOpenAISchema,
+        api_key::AbstractString,
+        model::AbstractString,
+        conversation;
+        url::String = "https://api.groq.com/openai/v1",
+        kwargs...)
+    # Build the corresponding provider object
+    # try to override provided api_key because the default is OpenAI key
+    provider = CustomProvider(;
+        api_key = isempty(GROQ_API_KEY) ? api_key : GROQ_API_KEY,
+        base_url = url)
+    OpenAI.create_chat(provider, model, conversation; kwargs...)
+end
 function OpenAI.create_chat(schema::DatabricksOpenAISchema,
         api_key::AbstractString,
         model::AbstractString,

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -19,6 +19,7 @@ Check your preferences by calling `get_preferences(key::String)`.
 - `GOOGLE_API_KEY`: The API key for Google Gemini models. Get yours from [here](https://ai.google.dev/). If you see a documentation page ("Available languages and regions for Google AI Studio and Gemini API"), it means that it's not yet available in your region.
 - `ANTHROPIC_API_KEY`: The API key for the Anthropic API. Get yours from [here](https://www.anthropic.com/).
 - `VOYAGE_API_KEY`: The API key for the Voyage API. Free tier is upto 50M tokens! Get yours from [here](https://dash.voyageai.com/api-keys).
+- `GROQ_API_KEY`: The API key for the Groq API. Free in beta! Get yours from [here](https://console.groq.com/keys).
 - `MODEL_CHAT`: The default model to use for aigenerate and most ai* calls. See `MODEL_REGISTRY` for a list of available models or define your own.
 - `MODEL_EMBEDDING`: The default model to use for aiembed (embedding documents). See `MODEL_REGISTRY` for a list of available models or define your own.
 - `PROMPT_SCHEMA`: The default prompt schema to use for aigenerate and most ai* calls (if not specified in `MODEL_REGISTRY`). Set as a string, eg, `"OpenAISchema"`.
@@ -44,6 +45,7 @@ Define your `register_model!()` calls in your `startup.jl` file to make them ava
 - `GOOGLE_API_KEY`: The API key for Google Gemini models. Get yours from [here](https://ai.google.dev/). If you see a documentation page ("Available languages and regions for Google AI Studio and Gemini API"), it means that it's not yet available in your region.
 - `ANTHROPIC_API_KEY`: The API key for the Anthropic API. Get yours from [here](https://www.anthropic.com/).
 - `VOYAGE_API_KEY`: The API key for the Voyage API. Free tier is upto 50M tokens! Get yours from [here](https://dash.voyageai.com/api-keys).
+- `GROQ_API_KEY`: The API key for the Groq API. Free in beta! Get yours from [here](https://console.groq.com/keys).
 
 Preferences.jl takes priority over ENV variables, so if you set a preference, it will take precedence over the ENV variable.
 
@@ -61,6 +63,7 @@ const ALLOWED_PREFERENCES = ["MISTRALAI_API_KEY",
     "GOOGLE_API_KEY",
     "ANTHROPIC_API_KEY",
     "VOYAGE_API_KEY",
+    "GROQ_API_KEY",
     "MODEL_CHAT",
     "MODEL_EMBEDDING",
     "MODEL_ALIASES",
@@ -166,6 +169,14 @@ const FIREWORKS_API_KEY::String = @load_preference("FIREWORKS_API_KEY",
 
 _temp = get(ENV, "ANTHROPIC_API_KEY", "")
 const ANTHROPIC_API_KEY::String = @load_preference("ANTHROPIC_API_KEY",
+    default=_temp);
+
+_temp = get(ENV, "VOYAGE_API_KEY", "")
+const VOYAGE_API_KEY::String = @load_preference("VOYAGE_API_KEY",
+    default=_temp);
+
+_temp = get(ENV, "GROQ_API_KEY", "")
+const GROQ_API_KEY::String = @load_preference("GROQ_API_KEY",
     default=_temp);
 
 _temp = get(ENV, "LOCAL_SERVER", "http://localhost:10897/v1")
@@ -324,7 +335,14 @@ aliases = merge(
         "claude" => "claude-3-sonnet-20240229",
         "claudeo" => "claude-3-opus-20240229",
         "claudes" => "claude-3-sonnet-20240229",
-        "claudeh" => "claude-3-haiku-20240307"),
+        "claudeh" => "claude-3-haiku-20240307",
+        ## Groq
+        "gllama3" => "llama3-8b-8192",
+        "gl3" => "llama3-8b-8192",
+        "gllama370" => "llama3-70b-8192",
+        "gl70" => "llama3-70b-8192",
+        "gmixtral" => "mixtral-8x7b-32768"
+    ),
     ## Load aliases from preferences as well
     @load_preference("MODEL_ALIASES", default=Dict{String, String}()))
 
@@ -612,7 +630,24 @@ registry = Dict{String, ModelSpec}(
         AnthropicSchema(),
         8e-6,
         2.4e-5,
-        "Anthropic's Claude 2.1 model."))
+        "Anthropic's Claude 2.1 model."),
+    ## Groq -- using preliminary pricing on https://wow.groq.com/
+    "llama3-8b-8192" => ModelSpec("llama3-8b-8192",
+        GroqOpenAISchema(),
+        5e-8,
+        1e-7,
+        "Meta's Llama3 8b, hosted by Groq. Max output 8192 tokens, 8K context. See details [here](https://console.groq.com/docs/models)"),
+    "llama3-70b-8192" => ModelSpec("llama3-70b-8192",
+        GroqOpenAISchema(),
+        5.9e-7,
+        7.9e-7,
+        "Meta's Llama3 70b, hosted by Groq. Max output 8192 tokens, 8K context. See details [here](https://console.groq.com/docs/models)"),
+    "mixtral-8x7b-32768" => ModelSpec("mixtral-8x7b-32768",
+        GroqOpenAISchema(),
+        2.7e-7,
+        2.7e-7,
+        "Mistral.ai Mixtral 8x7b, hosted by Groq. Max 32K context. See details [here](https://console.groq.com/docs/models)")
+)
 
 """
     ALTERNATIVE_GENERATION_COSTS

--- a/templates/RAG/refinement/RAGAnswerRefiner.json
+++ b/templates/RAG/refinement/RAGAnswerRefiner.json
@@ -1,1 +1,24 @@
-[{"content":"Template Metadata","description":"For RAG applications (refine step), gives model the ability to refine its answer based on some additional context etc.. The hope is that it better answers the original query. Placeholders: `query`, `answer`, `context`","version":"1.0","source":"Adapted from [LlamaIndex](https://github.com/run-llama/llama_index/blob/78af3400ad485e15862c06f0c4972dc3067f880c/llama-index-core/llama_index/core/prompts/default_prompts.py#L81)","_type":"metadatamessage"},{"content":"Act as a world-class AI assistant with access to the latest knowledge via Context Information.\n\nYour task is to refine an existing answer if it's needed.\n\nThe original query is as follows: \n{{query}}\n\nThe AI model has provided the following answer:\n{{answer}}\n\n**Instructions:**\n- Given the new context, refine the original answer to better answer the query.\n- If the context isn't useful, return the original answer.\n- If you don't know the answer, just say that you don't know, don't try to make up an answer.\n- Be brief and concise.\n- Provide the refined answer only and nothing else.\n\n","variables":["query","answer"],"_type":"systemmessage"},{"content":"We have the opportunity to refine the previous answer (only if needed) with some more context below.\n\n**Context Information:**\n-----------------\n{{context}}\n-----------------\n\nGiven the new context, refine the original answer to better answer the query.\nIf the context isn't useful, return the original answer. \nProvide the refined answer only and nothing else.\n\nRefined Answer: ","variables":["context"],"_type":"usermessage"}]
+[
+    {
+        "content": "Template Metadata",
+        "description": "For RAG applications (refine step), gives model the ability to refine its answer based on some additional context etc.. The hope is that it better answers the original query. Placeholders: `query`, `answer`, `context`",
+        "version": "1.1",
+        "source": "Adapted from [LlamaIndex](https://github.com/run-llama/llama_index/blob/78af3400ad485e15862c06f0c4972dc3067f880c/llama-index-core/llama_index/core/prompts/default_prompts.py#L81)",
+        "_type": "metadatamessage"
+    },
+    {
+        "content": "Act as a world-class AI assistant with access to the latest knowledge via Context Information.\n\nYour task is to refine an existing answer if it's needed.\n\nThe original query is as follows: \n{{query}}\n\nThe AI model has provided the following answer:\n{{answer}}\n\n**Instructions:**\n- Given the new context, refine the original answer to better answer the query.\n- If the context isn't useful, return the original answer.\n- If you don't know the answer, just say that you don't know, don't try to make up an answer.\n- Be brief and concise.\n- Provide the refined answer only and nothing else.\n\n",
+        "variables": [
+            "query",
+            "answer"
+        ],
+        "_type": "systemmessage"
+    },
+    {
+        "content": "We have the opportunity to refine the previous answer (only if needed) with some more context below.\n\n**Context Information:**\n-----------------\n{{context}}\n-----------------\n\nGiven the new context, refine the original answer to better answer the query.\nIf the context isn't useful, return the original answer. \nProvide the refined answer only and nothing else. You MUST NOT comment on the web search results or the answer - simply provide the answer to the question.\n\nRefined Answer: ",
+        "variables": [
+            "context"
+        ],
+        "_type": "usermessage"
+    }
+]

--- a/templates/RAG/refinement/RAGWebSearchRefiner.json
+++ b/templates/RAG/refinement/RAGWebSearchRefiner.json
@@ -1,1 +1,24 @@
-[{"content":"Template Metadata","description":"For RAG applications (refine step), gives model the ability to refine its answer based on web search results. The hope is that it better answers the original query. Placeholders: `query`, `answer`, `search_results`","version":"1.0","source":"Adapted from [LlamaIndex](https://github.com/run-llama/llama_index/blob/78af3400ad485e15862c06f0c4972dc3067f880c/llama-index-core/llama_index/core/prompts/default_prompts.py#L81)","_type":"metadatamessage"},{"content":"Act as a world-class AI assistant with access to the latest knowledge via web search results.\n\nYour task is to refine an existing answer if it's needed.\n\nThe original query: \n-----------------\n{{query}}\n-----------------\n\nThe AI model has provided the following answer:\n-----------------\n{{answer}}\n-----------------\n\n**Instructions:**\n- Given the web search results, refine the original answer to better answer the query.\n- Web search results are sometimes irrelevant and noisy. If the results are not relevant for the query, return the original answer from the AI model.\n- If the web search results do not improve the original answer, return the original answer from the AI model.\n- If you don't know the answer, just say that you don't know, don't try to make up an answer.\n- Be brief and concise.\n- Provide the refined answer only and nothing else.\n\n","variables":["query","answer"],"_type":"systemmessage"},{"content":"We have the opportunity to refine the previous answer (only if needed) with additional information from web search.\n\n**Web Search Results:**\n-----------------\n{{search_results}}\n-----------------\n\nGiven the new context, refine the original answer to better answer the query.\nIf the web search results are not useful, return the original answer without any changes. \nProvide the refined answer only and nothing else.\n\nRefined Answer: ","variables":["search_results"],"_type":"usermessage"}]
+[
+    {
+        "content": "Template Metadata",
+        "description": "For RAG applications (refine step), gives model the ability to refine its answer based on web search results. The hope is that it better answers the original query. Placeholders: `query`, `answer`, `search_results`",
+        "version": "1.1",
+        "source": "Adapted from [LlamaIndex](https://github.com/run-llama/llama_index/blob/78af3400ad485e15862c06f0c4972dc3067f880c/llama-index-core/llama_index/core/prompts/default_prompts.py#L81)",
+        "_type": "metadatamessage"
+    },
+    {
+        "content": "Act as a world-class AI assistant with access to the latest knowledge via web search results.\n\nYour task is to refine an existing answer if it's needed.\n\nThe original query: \n-----------------\n{{query}}\n-----------------\n\nThe AI model has provided the following answer:\n-----------------\n{{answer}}\n-----------------\n\n**Instructions:**\n- Given the web search results, refine the original answer to better answer the query.\n- Web search results are sometimes irrelevant and noisy. If the results are not relevant for the query, return the original answer from the AI model.\n- If the web search results do not improve the original answer, return the original answer from the AI model.\n- If you don't know the answer, just say that you don't know, don't try to make up an answer.\n- Be brief and concise.\n- Provide the refined answer only and nothing else.\n\n",
+        "variables": [
+            "query",
+            "answer"
+        ],
+        "_type": "systemmessage"
+    },
+    {
+        "content": "We have the opportunity to refine the previous answer (only if needed) with additional information from web search.\n\n**Web Search Results:**\n-----------------\n{{search_results}}\n-----------------\n\nGiven the new context, refine the original answer to better answer the query.\nIf the web search results are not useful, return the original answer without any changes.\nProvide the refined answer only and nothing else. You MUST NOT comment on the web search results or the answer - simply provide the answer to the question.\n\nRefined Answer: ",
+        "variables": [
+            "search_results"
+        ],
+        "_type": "usermessage"
+    }
+]


### PR DESCRIPTION
- Added support for [Groq](https://console.groq.com/), the fastest LLM provider out there. It's free for now, so you can try it out - you just need to set your `GROQ_API_KEY`. We've added Llama3 8b (alias "gllama3"), 70b (alias "gllama370") and Mixtral 8x7b (alias "gmixtral"). For the shortcut junkies, we also added a shorthand Llama3 8b = "gl3" (first two letters and the last digit), Llama3 70b = "gl70" (first two letters and the last two digits).
