### PR TITLE
Add DeepSeek models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added support for [DeepSeek models](https://platform.deepseek.com/docs) via the `dschat` and `dscode` aliases. You can set the `DEEPSEEK_API_KEY` environment variable to your DeepSeek API key.
 
 ### Fixed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.23.0"
+version = "0.24.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -192,6 +192,20 @@ Requires one environment variables to be set:
 """
 struct GroqOpenAISchema <: AbstractOpenAISchema end
 
+"""
+    DeepSeekOpenAISchema
+
+Schema to call the [DeepSeek](https://platform.deepseek.com/docs) API.
+
+Links:
+- [Get your API key](https://platform.deepseek.com/api_keys)
+- [API Reference](https://platform.deepseek.com/docs)
+
+Requires one environment variables to be set:
+- `DEEPSEEK_API_KEY`: Your API key (often starts with "sk-...")
+"""
+struct DeepSeekOpenAISchema <: AbstractOpenAISchema end
+
 abstract type AbstractOllamaSchema <: AbstractPromptSchema end
 
 """

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -205,6 +205,19 @@ function OpenAI.create_chat(schema::GroqOpenAISchema,
         base_url = url)
     OpenAI.create_chat(provider, model, conversation; kwargs...)
 end
+function OpenAI.create_chat(schema::DeepSeekOpenAISchema,
+        api_key::AbstractString,
+        model::AbstractString,
+        conversation;
+        url::String = "https://api.deepseek.com/v1",
+        kwargs...)
+    # Build the corresponding provider object
+    # try to override provided api_key because the default is OpenAI key
+    provider = CustomProvider(;
+        api_key = isempty(DEEPSEEK_API_KEY) ? api_key : DEEPSEEK_API_KEY,
+        base_url = url)
+    OpenAI.create_chat(provider, model, conversation; kwargs...)
+end
 function OpenAI.create_chat(schema::DatabricksOpenAISchema,
         api_key::AbstractString,
         model::AbstractString,

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -20,6 +20,7 @@ Check your preferences by calling `get_preferences(key::String)`.
 - `ANTHROPIC_API_KEY`: The API key for the Anthropic API. Get yours from [here](https://www.anthropic.com/).
 - `VOYAGE_API_KEY`: The API key for the Voyage API. Free tier is upto 50M tokens! Get yours from [here](https://dash.voyageai.com/api-keys).
 - `GROQ_API_KEY`: The API key for the Groq API. Free in beta! Get yours from [here](https://console.groq.com/keys).
+- `DEEPSEEK_API_KEY`: The API key for the DeepSeek API. Get \$5 credit when you join. Get yours from [here](https://platform.deepseek.com/api_keys).
 - `MODEL_CHAT`: The default model to use for aigenerate and most ai* calls. See `MODEL_REGISTRY` for a list of available models or define your own.
 - `MODEL_EMBEDDING`: The default model to use for aiembed (embedding documents). See `MODEL_REGISTRY` for a list of available models or define your own.
 - `PROMPT_SCHEMA`: The default prompt schema to use for aigenerate and most ai* calls (if not specified in `MODEL_REGISTRY`). Set as a string, eg, `"OpenAISchema"`.
@@ -46,6 +47,7 @@ Define your `register_model!()` calls in your `startup.jl` file to make them ava
 - `ANTHROPIC_API_KEY`: The API key for the Anthropic API. Get yours from [here](https://www.anthropic.com/).
 - `VOYAGE_API_KEY`: The API key for the Voyage API. Free tier is upto 50M tokens! Get yours from [here](https://dash.voyageai.com/api-keys).
 - `GROQ_API_KEY`: The API key for the Groq API. Free in beta! Get yours from [here](https://console.groq.com/keys).
+- `DEEPSEEK_API_KEY`: The API key for the DeepSeek API. Get \$5 credit when you join. Get yours from [here](https://platform.deepseek.com/api_keys).
 
 Preferences.jl takes priority over ENV variables, so if you set a preference, it will take precedence over the ENV variable.
 
@@ -64,6 +66,7 @@ const ALLOWED_PREFERENCES = ["MISTRALAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "VOYAGE_API_KEY",
     "GROQ_API_KEY",
+    "DEEPSEEK_API_KEY",
     "MODEL_CHAT",
     "MODEL_EMBEDDING",
     "MODEL_ALIASES",
@@ -177,6 +180,10 @@ const VOYAGE_API_KEY::String = @load_preference("VOYAGE_API_KEY",
 
 _temp = get(ENV, "GROQ_API_KEY", "")
 const GROQ_API_KEY::String = @load_preference("GROQ_API_KEY",
+    default=_temp);
+
+_temp = get(ENV, "DEEPSEEK_API_KEY", "")
+const DEEPSEEK_API_KEY::String = @load_preference("DEEPSEEK_API_KEY",
     default=_temp);
 
 _temp = get(ENV, "LOCAL_SERVER", "http://localhost:10897/v1")
@@ -342,6 +349,9 @@ aliases = merge(
         "gllama370" => "llama3-70b-8192",
         "gl70" => "llama3-70b-8192",
         "gmixtral" => "mixtral-8x7b-32768"
+        ## DeepSeek
+        "dschat" => "deepseek-chat",
+        "dscode" => "deepseek-coder"
     ),
     ## Load aliases from preferences as well
     @load_preference("MODEL_ALIASES", default=Dict{String, String}()))
@@ -646,7 +656,17 @@ registry = Dict{String, ModelSpec}(
         GroqOpenAISchema(),
         2.7e-7,
         2.7e-7,
-        "Mistral.ai Mixtral 8x7b, hosted by Groq. Max 32K context. See details [here](https://console.groq.com/docs/models)")
+        "Mistral.ai Mixtral 8x7b, hosted by Groq. Max 32K context. See details [here](https://console.groq.com/docs/models)"),
+    "deepseek-chat" => ModelSpec("deepseek-chat",
+        DeepSeekOpenAISchema(),
+        1.4e-7,
+        2.8e-7,
+        "Deepseek.com-hosted DeepSeekV2 model. Max 32K context. See details [here](https://platform.deepseek.com/docs)"),
+    "deepseek-coder" => ModelSpec("deepseek-coder",
+        DeepSeekOpenAISchema(),
+        1.4e-7,
+        2.8e-7,
+        "Deepseek.com-hosted coding model. Max 16K context. See details [here](https://platform.deepseek.com/docs)")
 )
 
 """

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -348,7 +348,7 @@ aliases = merge(
         "gl3" => "llama3-8b-8192",
         "gllama370" => "llama3-70b-8192",
         "gl70" => "llama3-70b-8192",
-        "gmixtral" => "mixtral-8x7b-32768"
+        "gmixtral" => "mixtral-8x7b-32768",
         ## DeepSeek
         "dschat" => "deepseek-chat",
         "dscode" => "deepseek-coder"


### PR DESCRIPTION
- Added support for [DeepSeek models](https://platform.deepseek.com/docs) via the `dschat` and `dscode` aliases. You can set the `DEEPSEEK_API_KEY` environment variable to your DeepSeek API key.
