### PR TITLE
Add GPT4-Omni

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added support for [DeepSeek models](https://platform.deepseek.com/docs) via the `dschat` and `dscode` aliases. You can set the `DEEPSEEK_API_KEY` environment variable to your DeepSeek API key.
 
 ### Fixed
+
+## [0.25.0]
+
+### Added
+- Added model registry record for the latest OpenAI GPT4 Omni model (`gpt4o`) - it's as good as GPT4, faster and cheaper.
 
 ## [0.24.0]
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.24.0"
+version = "0.25.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -307,6 +307,7 @@ end
 aliases = merge(
     Dict("gpt3" => "gpt-3.5-turbo",
         "gpt4" => "gpt-4",
+        "gpt4o" => "gpt-4o",
         "gpt4v" => "gpt-4-vision-preview", # 4v is for "4 vision"
         "gpt4t" => "gpt-4-turbo", # 4t is for "4 turbo"
         "gpt3t" => "gpt-3.5-turbo-0125", # 3t is for "3 turbo"
@@ -402,7 +403,18 @@ registry = Dict{String, ModelSpec}(
         1e-5,
         3e-5,
         "GPT-4 Turbo is an updated version of GPT4 that is much faster and the cheaper to use. This is the general name for whatever is the latest GPT4 Turbo preview release. Right now it is 0125."),
-    "gpt-4-vision-preview" => ModelSpec("gpt-4-vision-preview",
+    "gpt-4o-2024-05-13" => ModelSpec("gpt-4o-2024-05-13",
+        OpenAISchema(),
+        5e-6,
+        1.5e-5,
+        "GPT-4 Omni, the latest GPT4 model that is faster and cheaper than GPT-4 Turbo is an updated version of GPT4 that is much faster and the cheaper to use."),
+    "gpt-4o" => ModelSpec("gpt-4o",
+        OpenAISchema(),
+        5e-6,
+        1.5e-5,
+        "GPT-4 Omni, the latest GPT4 model that is faster and cheaper than GPT-4 Turbo is an updated version of GPT4 that is much faster and the cheaper to use. Currently points to version gpt-4o-2024-05-13."),
+    "gpt-4-vision-preview" => ModelSpec(
+        "gpt-4-vision-preview",
         OpenAISchema(),
         1e-5,
         3e-5,


### PR DESCRIPTION
- Added model registry record for the latest OpenAI GPT4 Omni model (`gpt4o`) - it's as good as GPT4, faster and cheaper.