### PR TITLE
Add BitPacked embeddings for RAG retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new field `meta` to `TracerMessage` and `TracerMessageLike` to hold metadata in a simply dictionary. Change is backward-compatible.
 - Changed behaviour of `aitemplates(name::Symbol)` to look for the exact match on the template name, not just a partial match. This is a breaking change for the `aitemplates` function only. Motivation is that having multiple matches could have introduced subtle bugs when looking up valid placeholders for a template.
 
-
 ### Added
 - Improved support for `aiclassify` with OpenAI models (you can now encode upto 40 choices).
 - Added a template for routing questions `:QuestionRouter` (to be used with `aiclassify`)
-- Improved tracing by `TracerSchema` to automatically capture crucial metadata such as any LLM API kwargs (`api_kwargs`), use of prompt templates and its versions. Information is captured in `meta(tracer)` dictionary. See `?TracerSchema` for more information.
+- Improved tracing by `TracerSchema` to automatically capture crucial metadata such as any LLM API kwargs (`api_kwargs`), use of prompt templates and its version. Information is captured in `meta(tracer)` dictionary. See `?TracerSchema` for more information.
 - New tracing schema `SaverSchema` allows to automatically serialize all conversations. It can be composed with other tracing schemas, eg, `TracerSchema` to automatically capture necessary metadata and serialize. See `?SaverSchema` for more information.
+- Updated options for Binary embeddings (refer to release v0.18 for motivation). Adds utility functions `pack_bits` and `unpack_bits` to move between binary and UInt64 representations of embeddings. RAGTools adds the corresponding `BitPackedBatchEmbedder` and `BitPackedCosineSimilarity` for fast retrieval on these Bool<->UInt64 embeddings (credit to [**domluna's tinyRAG**](https://github.com/domluna/tinyRAG)).
 
 ### Fixed
 - Fixed a bug where `aiclassify` would not work when returning the full conversation for choices with extra descriptions

--- a/src/Experimental/RAGTools/preparation.jl
+++ b/src/Experimental/RAGTools/preparation.jl
@@ -31,15 +31,27 @@ struct BatchEmbedder <: AbstractEmbedder end
 """
     BinaryBatchEmbedder <: AbstractEmbedder
 
-Same as `BatchEmbedder` but reduces the embeddings matrix to binary tool (eg, `BitMatrix`).
+Same as `BatchEmbedder` but reduces the embeddings matrix to a binary form (eg, `BitMatrix`).
 
 Reference: [HuggingFace: Embedding Quantization](https://huggingface.co/blog/embedding-quantization#binary-quantization-in-vector-databases).
 """
 struct BinaryBatchEmbedder <: AbstractEmbedder end
 
+"""
+    BitPackedBatchEmbedder <: AbstractEmbedder
+
+Same as `BatchEmbedder` but reduces the embeddings matrix to a binary form packed in UInt64 (eg, `BitMatrix.chunks`).
+
+See also utilities `pack_bits` and `unpack_bits` to move between packed/non-packed binary forms.
+
+Reference: [HuggingFace: Embedding Quantization](https://huggingface.co/blog/embedding-quantization#binary-quantization-in-vector-databases).
+"""
+struct BitPackedBatchEmbedder <: AbstractEmbedder end
+
 EmbedderEltype(::T) where {T} = EmbedderEltype(T)
 EmbedderEltype(::Type{<:AbstractEmbedder}) = Float32
 EmbedderEltype(::Type{BinaryBatchEmbedder}) = Bool
+EmbedderEltype(::Type{BitPackedBatchEmbedder}) = UInt64
 
 ### Tagging Types
 """
@@ -300,6 +312,56 @@ function get_embeddings(
         cost_tracker, target_batch_size_length, ntasks, kwargs...)
     # This will return BitMatrix to save space, for best performance use Matrix{Bool}, eg, map(>(0),emb)
     emb = (emb .> 0) |> x -> x isa return_type ? x : return_type(x)
+end
+
+"""
+    get_embeddings(embedder::BitPackedBatchEmbedder, docs::AbstractVector{<:AbstractString};
+        verbose::Bool = true,
+        model::AbstractString = PT.MODEL_EMBEDDING,
+        truncate_dimension::Union{Int, Nothing} = nothing,
+        cost_tracker = Threads.Atomic{Float64}(0.0),
+        target_batch_size_length::Int = 80_000,
+        ntasks::Int = 4 * Threads.nthreads(),
+        kwargs...)
+      
+
+Embeds a vector of `docs` using the provided model (kwarg `model`) in a batched manner and then returns the binary embeddings matrix represented in UInt64 (bit-packed) - `BitPackedBatchEmbedder`.
+
+`BitPackedBatchEmbedder` tries to batch embedding calls for roughly 80K characters per call (to avoid exceeding the API rate limit) to reduce network latency.
+
+The best option for FAST and MEMORY-EFFICIENT storage of embeddings, for retrieval use `BitPackedCosineSimilarity`.
+
+# Notes
+- `docs` are assumed to be already chunked to the reasonable sizes that fit within the embedding context limit.
+- If you get errors about exceeding input sizes, first check the `max_length` in your chunks. 
+  If that does NOT resolve the issue, try reducing the `target_batch_size_length` parameter (eg, 10_000) and number of tasks `ntasks=1`. 
+  Some providers cannot handle large batch sizes.
+
+# Arguments
+- `docs`: A vector of strings to be embedded.
+- `verbose`: A boolean flag for verbose output. Default is `true`.
+- `model`: The model to use for embedding. Default is `PT.MODEL_EMBEDDING`.
+- `truncate_dimension`: The dimensionality of the embeddings to truncate to. Default is `nothing`.
+- `cost_tracker`: A `Threads.Atomic{Float64}` object to track the total cost of the API calls. Useful to pass the total cost to the parent call.
+- `target_batch_size_length`: The target length (in characters) of each batch of document chunks sent for embedding. Default is 80_000 characters. Speeds up embedding process.
+- `ntasks`: The number of tasks to use for asyncmap. Default is 4 * Threads.nthreads().
+
+See also: `unpack_bits`, `pack_bits`, `BitPackedCosineSimilarity`.
+"""
+function get_embeddings(
+        embedder::BitPackedBatchEmbedder, docs::AbstractVector{<:AbstractString};
+        verbose::Bool = true,
+        model::AbstractString = PT.MODEL_EMBEDDING,
+        truncate_dimension::Union{Int, Nothing} = nothing,
+        cost_tracker = Threads.Atomic{Float64}(0.0),
+        target_batch_size_length::Int = 80_000,
+        ntasks::Int = 4 * Threads.nthreads(),
+        kwargs...)
+    emb = get_embeddings(BatchEmbedder(), docs; verbose, model, truncate_dimension,
+        cost_tracker, target_batch_size_length, ntasks, kwargs...)
+    # This will return Matrix{UInt64} to save space
+    # Use unpack_bits to convert back to BitMatrix
+    pack_bits(emb .> 0)
 end
 
 ### Tag Extraction

--- a/test/Experimental/RAGTools/preparation.jl
+++ b/test/Experimental/RAGTools/preparation.jl
@@ -9,6 +9,7 @@ using PromptingTools.Experimental.RAGTools: build_tags, build_index, SimpleIndex
                                             get_tags, get_chunks, get_embeddings
 using PromptingTools.Experimental.RAGTools: build_tags, build_index
 using PromptingTools: TestEchoOpenAISchema
+using PromptingTools.Experimental.RAGTools: pack_bits, BitPackedBatchEmbedder
 
 @testset "load_text" begin
     # from file
@@ -80,9 +81,17 @@ end
     @test size(output) == (100, 2)
     @test eltype(output) == Bool
 
+    # BitPackedBatchEmbedder
+    output = get_embeddings(
+        BitPackedBatchEmbedder(), docs; model = "mock-emb")
+    @test size(output) == (2, 2)
+    @test eltype(output) == UInt64
+    output = pack_bits(ones(Float32, 128, 2) .> 0)
+
     # EmbedderEltype
     @test EmbedderEltype(BinaryBatchEmbedder()) == Bool
     @test EmbedderEltype(BatchEmbedder()) == Float32
+    @test EmbedderEltype(BitPackedBatchEmbedder()) == UInt64
 end
 
 @testset "tags_extract" begin

--- a/test/Experimental/RAGTools/utils.jl
+++ b/test/Experimental/RAGTools/utils.jl
@@ -6,6 +6,7 @@ using PromptingTools.Experimental.RAGTools: token_with_boundaries, text_to_trigr
 using PromptingTools.Experimental.RAGTools: split_into_code_and_sentences
 using PromptingTools.Experimental.RAGTools: getpropertynested, setpropertynested,
                                             merge_kwargs_nested
+using PromptingTools.Experimental.RAGTools: pack_bits, unpack_bits
 
 @testset "_check_aiextract_capability" begin
     @test _check_aiextract_capability("gpt-3.5-turbo") == nothing
@@ -365,4 +366,77 @@ end
     nt2 = NamedTuple()
     expected = (; a = 1, b = (; c = 2))
     @test merge_kwargs_nested(nt1, nt2) == expected
+end
+
+@testset "pack_bits,unpack_bits" begin
+    ### Test for vectors
+    # Basic functionality
+    bin = rand(Bool, 128)
+    binint = pack_bits(bin)
+    binx = unpack_bits(binint)
+    @test bin == binx
+
+    # Edge cases
+    # Test with all true values
+    bin = trues(128)
+    binint = pack_bits(bin)
+    binx = unpack_bits(binint)
+    @test bin == binx
+
+    # Test with all false values
+    bin = falses(128)
+    binint = pack_bits(bin)
+    binx = unpack_bits(binint)
+    @test bin == binx
+
+    # Test with alternating true and false values
+    bin = Bool[mod(i, 2) == 0 for i in 1:128]
+    binint = pack_bits(bin)
+    binx = unpack_bits(binint)
+    @test bin == binx
+
+    # empty vector
+    bin_empty = Bool[]
+    binint_empty = pack_bits(bin_empty)
+    binx_empty = unpack_bits(binint_empty)
+    @test bin_empty == binx_empty
+
+    # Invalid input
+    # Test with length not divisible by 64
+    bin = rand(Bool, 130)
+    @test_throws AssertionError pack_bits(bin)
+    @test_throws ArgumentError pack_bits(rand(Float32, 128))
+
+    ### Test for matrices
+    # Basic functionality
+    bin = rand(Bool, 128, 10)
+    binint = pack_bits(bin)
+    binx = unpack_bits(binint)
+    @test bin == binx
+
+    # Edge cases
+    # Test with all true values
+    bin = trues(128, 10)
+    binint = pack_bits(bin)
+    binx = unpack_bits(binint)
+    @test bin == binx
+
+    # Test with all false values
+    bin = falses(128, 10)
+    binint = pack_bits(bin)
+    binx = unpack_bits(binint)
+    @test bin == binx
+
+    # Test with alternating true and false values
+    bin = Bool[mod(i, 2) == 0 for i in 1:128, j in 1:10]
+    binint = pack_bits(bin)
+    binx = unpack_bits(binint)
+    @test bin == binx
+
+    # Invalid input
+    # Test with number of rows not divisible by 64
+    bin = rand(Bool, 130, 10)
+    @test_throws AssertionError pack_bits(bin)
+    # Wrong number type
+    @test_throws ArgumentError pack_bits(rand(Float32, 128, 10))
 end

--- a/test/Experimental/RAGTools/utils.jl
+++ b/test/Experimental/RAGTools/utils.jl
@@ -406,6 +406,7 @@ end
     bin = rand(Bool, 130)
     @test_throws AssertionError pack_bits(bin)
     @test_throws ArgumentError pack_bits(rand(Float32, 128))
+    @test_throws ArgumentError unpack_bits(rand(Float32, 128))
 
     ### Test for matrices
     # Basic functionality
@@ -439,4 +440,5 @@ end
     @test_throws AssertionError pack_bits(bin)
     # Wrong number type
     @test_throws ArgumentError pack_bits(rand(Float32, 128, 10))
+    @test_throws ArgumentError unpack_bits(rand(Float32, 128, 10))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using OpenAI, HTTP, JSON3
 using SparseArrays, LinearAlgebra, Markdown
 using Statistics
 using Dates: now
-using Test, Pkg
+using Test, Pkg, Random
 const PT = PromptingTools
 using Aqua
 


### PR DESCRIPTION
- Updated options for Binary embeddings (refer to release v0.18 for motivation). Adds utility functions `pack_bits` and `unpack_bits` to move between binary and UInt64 representations of embeddings. RAGTools adds the corresponding `BitPackedBatchEmbedder` and `BitPackedCosineSimilarity` for fast retrieval on these Bool<->UInt64 embeddings (credit to [**domluna's tinyRAG**](https://github.com/domluna/tinyRAG)).