### PR TITLE
Template file parsing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.26.2]
+
+### Fixed
+- Fixed a rare bug where prompt templates created on MacOS will come with metadata that breaks the prompt loader. From now on, it ignores any dotfiles (hidden files starting with ".").
+
 ## [0.26.1]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.26.1"
+version = "0.26.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/templates.jl
+++ b/src/templates.jl
@@ -234,7 +234,7 @@ function load_templates!(dir_templates::Union{String, Nothing} = nothing;
     for template_path in load_paths
         for (root, dirs, files) in walkdir(template_path)
             for file in files
-                if endswith(file, ".json")
+                if endswith(file, ".json") && !startswith(file, ".")
                     template_name = Symbol(split(basename(file), ".")[begin])
                     template, metadata_msgs = load_template(joinpath(root, file))
                     # add to store

--- a/test/templates.jl
+++ b/test/templates.jl
@@ -81,12 +81,12 @@ end
     tpl = create_template(; system = "a", user = "b")
     mktempdir() do dir
         ## File to be visible
-        fn = joinpath("x", "x1.json")
-        save_conversation(dir, tpl)
+        fn = joinpath(dir, "x1.json")
+        save_conversation(fn, tpl)
 
         ## File to be invisible
-        fn = joinpath("x", "._x2.json")
-        save_conversation(dir, tpl)
+        fn = joinpath(dir, "._x2.json")
+        save_conversation(fn, tpl)
 
         store = Dict{Symbol, Any}()
         PT.load_templates!(dir;


### PR DESCRIPTION
- Fixed a rare bug where prompt templates created on MacOS will come with metadata that breaks the prompt loader. From now on, it ignores any dotfiles (hidden files starting with ".").
