### PR TITLE
Add BM25 Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.27.0]
 
 ### Added
-- Added a keyword-based search similarity to RAGTools to serve both for baseline evaluation and for advanced performance (by having a hybrid index with both embeddings and BM25). See `?RT.xyz` for more information.
+- Added a keyword-based search similarity to RAGTools to serve both for baseline evaluation and for advanced performance (by having a hybrid index with both embeddings and BM25). See `?RT.KeywordsIndexer` and `?RT.BM25Similarity` for more information.
 
 ## [0.26.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.27.0]
+
+### Added
+- Added a keyword-based search similarity to RAGTools to serve both for baseline evaluation and for advanced performance (by having a hybrid index with both embeddings and BM25). See `?RT.xyz` for more information.
+
 ## [0.26.2]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -23,11 +23,12 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Snowball = "fb8f903a-0164-4e73-9ffe-431110250c3b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [extensions]
 GoogleGenAIPromptingToolsExt = ["GoogleGenAI"]
 MarkdownPromptingToolsExt = ["Markdown"]
-RAGToolsExperimentalExt = ["SparseArrays", "LinearAlgebra"]
+RAGToolsExperimentalExt = ["SparseArrays", "LinearAlgebra", "Unicode"]
 SnowballPromptingToolsExt = ["Snowball"]
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.26.2"
+version = "0.27.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -21,12 +21,14 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 GoogleGenAI = "903d41d1-eaca-47dd-943b-fee3930375ab"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Snowball = "fb8f903a-0164-4e73-9ffe-431110250c3b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extensions]
 GoogleGenAIPromptingToolsExt = ["GoogleGenAI"]
 MarkdownPromptingToolsExt = ["Markdown"]
 RAGToolsExperimentalExt = ["SparseArrays", "LinearAlgebra"]
+SnowballPromptingToolsExt = ["Snowball"]
 
 [compat]
 AbstractTrees = "0.4"
@@ -56,4 +58,4 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [targets]
-test = ["Aqua", "SparseArrays", "Statistics", "LinearAlgebra", "Markdown"]
+test = ["Aqua", "SparseArrays", "Statistics", "LinearAlgebra", "Markdown", "Snowball"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,6 +10,7 @@ Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 PromptingTools = "670122d1-24a8-4d70-bfce-740807c42192"
+Snowball = "fb8f903a-0164-4e73-9ffe-431110250c3b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/ext/RAGToolsExperimentalExt.jl
+++ b/ext/RAGToolsExperimentalExt.jl
@@ -1,14 +1,19 @@
 module RAGToolsExperimentalExt
 
-using PromptingTools, SparseArrays
-using LinearAlgebra: normalize
+using PromptingTools, SparseArrays, Unicode
+using LinearAlgebra
 const PT = PromptingTools
 
 using PromptingTools.Experimental.RAGTools
 const RT = PromptingTools.Experimental.RAGTools
 
 # forward to LinearAlgebra.normalize
-RT._normalize(arr::AbstractArray) = normalize(arr)
+RT._normalize(arr::AbstractArray) = LinearAlgebra.normalize(arr)
+
+# Forward to Unicode.normalize
+function RT._unicode_normalize(text::AbstractString; kwargs...)
+    Unicode.normalize(text; kwargs...)
+end
 
 """
     RT.build_tags(

--- a/ext/RAGToolsExperimentalExt.jl
+++ b/ext/RAGToolsExperimentalExt.jl
@@ -40,4 +40,86 @@ function RT.build_tags(
     return tags_, tags_vocab_
 end
 
+"""
+    document_term_matrix(documents::AbstractVector{<:AbstractVector{<:AbstractString}})
+
+Builds a sparse matrix of term frequencies and document lengths from the given vector of documents wrapped in type `DocumentTermMatrix`.
+
+Expects a vector of preprocessed (tokenized) documents, where each document is a vector of strings (clean tokens).
+
+Returns: `DocumentTermMatrix`
+
+# Example
+```
+documents = [["this", "is", "a", "test"], ["this", "is", "another", "test"], ["foo", "bar", "baz"]]
+dtm = document_term_matrix(documents)
+```
+"""
+function RT.document_term_matrix(documents::AbstractVector{<:AbstractVector{<:AbstractString}})
+    vocab = unique(vcat(documents...))
+    vocab_lookup = Dict(t => i for (i, t) in enumerate(vocab))
+    N = length(documents)
+    doc_freq = zeros(Int, length(vocab))
+    term_freq = spzeros(Float32, N, length(vocab))
+    doc_lengths = zeros(Float32, N)
+    for di in eachindex(documents)
+        unique_terms = Set{eltype(vocab)}()
+        doc = documents[di]
+        for t in doc
+            doc_lengths[di] += 1
+            tid = vocab_lookup[t]
+            term_freq[di, tid] += 1
+            if !(t in unique_terms)
+                doc_freq[tid] += 1
+                push!(unique_terms, t)
+            end
+        end
+    end
+    idf = @. log(1.0f0 + (N - doc_freq + 0.5f0) / (doc_freq + 0.5f0))
+    sumdl = sum(doc_lengths)
+    doc_rel_length = sumdl == 0 ? zeros(Float32, N) : doc_lengths ./ (sumdl / N)
+    RT.DocumentTermMatrix(term_freq, vocab, vocab_lookup, idf, doc_rel_length)
+end
+"""
+    RT.bm25(dtm::DocumentTermMatrix, query::Vector{String}; k1::Float32=1.2f0, b::Float32=0.75f0)
+
+Scores all documents in `dtm` based on the `query`.
+
+References: https://opensourceconnections.com/blog/2015/10/16/bm25-the-next-generation-of-lucene-relevation/
+
+# Example
+```
+documents = [["this", "is", "a", "test"], ["this", "is", "another", "test"], ["foo", "bar", "baz"]]
+dtm = document_term_matrix(documents)
+query = ["this"]
+scores = bm25(dtm, query)
+# Returns array with 3 scores (one for each document)
+```
+"""
+function RT.bm25(dtm::RT.DocumentTermMatrix, query::Vector{String};
+        k1::Float32 = 1.2f0, b::Float32 = 0.75f0)
+    scores = zeros(Float32, size(dtm.tf, 1))
+    ## Identify non-zero items to leverage the sparsity
+    nz_rows = rowvals(dtm.tf)
+    nz_vals = nonzeros(dtm.tf)
+    for i in eachindex(query)
+        t = query[i]
+        t_id = get(dtm.vocab_lookup, t, nothing)
+        t_id === nothing && continue
+        idf = dtm.idf[t_id]
+        # Scan only documents that have this token
+        @inbounds @simd for j in nzrange(dtm.tf, t_id)
+            ## index into the sparse matrix
+            di, tf = nz_rows[j], nz_vals[j]
+            doc_len = dtm.doc_rel_length[di]
+            tf_top = (tf * (k1 + 1.0f0))
+            tf_bottom = (tf + k1 * (1.0f0 - b + b * doc_len))
+            score = idf * tf_top / tf_bottom
+            ## @info "di: $di, tf: $tf, doc_len: $doc_len, idf: $idf, tf_top: $tf_top, tf_bottom: $tf_bottom, score: $score"
+            scores[di] += score
+        end
+    end
+    scores
+end
+
 end # end of module

--- a/ext/SnowballPromptingToolsExt.jl
+++ b/ext/SnowballPromptingToolsExt.jl
@@ -1,0 +1,13 @@
+module SnowballPromptingToolsExt
+
+using PromptingTools
+const PT = PromptingTools
+
+using PromptingTools.Experimental.RAGTools
+const RT = PromptingTools.Experimental.RAGTools
+
+using Snowball
+
+# forward to Stemmer.stem
+RT._stem(stemmer::Snowball.Stemmer, text::AbstractString) = Snowball.stem(stemmer, text)
+end # end of module

--- a/ext/SnowballPromptingToolsExt.jl
+++ b/ext/SnowballPromptingToolsExt.jl
@@ -10,4 +10,53 @@ using Snowball
 
 # forward to Stemmer.stem
 RT._stem(stemmer::Snowball.Stemmer, text::AbstractString) = Snowball.stem(stemmer, text)
+
+"""
+    get_keywords(processor::KeywordsProcessor, docs::AbstractVector{<:AbstractString};
+        verbose::Bool = true,
+        stemmer = nothing,
+        stopwords::Set{String} = Set(STOPWORDS),
+        return_keywords::Bool = false,
+        kwargs...)
+
+Generate a `DocumentTermMatrix` from a vector of `docs` using the provided `stemmer` and `stopwords`.
+
+# Arguments
+- `docs`: A vector of strings to be embedded.
+- `verbose`: A boolean flag for verbose output. Default is `true`.
+- `stemmer`: A stemmer to use for stemming. Default is `nothing`.
+- `stopwords`: A set of stopwords to remove. Default is `Set(STOPWORDS)`.
+- `return_keywords`: A boolean flag for returning the keywords. Default is `false`. Useful for query processing in search time.
+"""
+function RT.get_keywords(
+        processor::RT.KeywordsProcessor, docs::AbstractVector{<:AbstractString};
+        verbose::Bool = true,
+        stemmer = nothing,
+        stopwords::Set{String} = Set(RT.STOPWORDS),
+        return_keywords::Bool = false,
+        kwargs...)
+    ## check if extension is available
+    ext = Base.get_extension(PromptingTools, :RAGToolsExperimentalExt)
+    if isnothing(ext)
+        error("You need to also import LinearAlgebra and SparseArrays to use this function")
+    end
+    ## ext = Base.get_extension(PromptingTools, :SnowballPromptingToolsExt)
+    ## if isnothing(ext)
+    ##     error("You need to also import Snowball.jl to use this function")
+    ## end
+    ## Preprocess text into tokens
+    stemmer = !isnothing(stemmer) ? stemmer : Snowball.Stemmer("english")
+    # Single-threaded as stemmer is not thread-safe
+    keywords = RT.preprocess_tokens(docs, stemmer; stopwords, min_length = 3)
+
+    ## Early exit if we only want keywords (search time)
+    return_keywords && return keywords
+
+    ## Create DTM
+    dtm = RT.document_term_matrix(keywords)
+
+    verbose && @info "Done processing DocumentTermMatrix."
+    return dtm
+end
+
 end # end of module

--- a/src/Experimental/RAGTools/RAGTools.jl
+++ b/src/Experimental/RAGTools/RAGTools.jl
@@ -32,11 +32,11 @@ include("api_services.jl")
 
 include("rag_interface.jl")
 
-export ChunkIndex, CandidateChunks, RAGResult
+export ChunkIndex, ChunkKeywordsIndex, ChunkEmbeddingsIndex, CandidateChunks, RAGResult
 # export MultiIndex # not ready yet
 include("types.jl")
 
-export build_index, get_chunks, get_embeddings, get_tags
+export build_index, get_chunks, get_embeddings, get_keywords, get_tags
 include("preparation.jl")
 
 export retrieve, SimpleRetriever, AdvancedRetriever

--- a/src/Experimental/RAGTools/preparation.jl
+++ b/src/Experimental/RAGTools/preparation.jl
@@ -394,17 +394,22 @@ end
 
 ## Supporting functions defined in RAGToolsExperimentalExt.jl because they require SparseArrays
 function document_term_matrix(documents)
-    throw(ArgumentError("You need to also import LinearAlgebra and SparseArrays to use this function"))
+    throw(ArgumentError("You need to also import LinearAlgebra, Unicode, and SparseArrays to use this function"))
 end
 
 function bm25(dtm, query; kwargs...)
-    throw(ArgumentError("You need to also import LinearAlgebra and SparseArrays to use this function"))
+    throw(ArgumentError("You need to also import LinearAlgebra, Unicode, and SparseArrays to use this function"))
 end
 
 function get_keywords(processor::AbstractProcessor, docs::AbstractVector{<:AbstractString};
         verbose::Bool = true,
         kwargs...)
-    throw(ArgumentError("Not implemented for processor $(typeof(processor))"))
+    ext = Base.get_extension(PromptingTools, :SnowballPromptingToolsExt)
+    if processor isa KeywordsProcessor && isnothing(ext)
+        throw(ArgumentError("You need to also import Snowball.jl to use this function"))
+    else
+        throw(ArgumentError("Not implemented for processor $(typeof(processor))."))
+    end
 end
 
 function get_keywords(processor::NoProcessor, docs::AbstractVector{<:AbstractString};
@@ -413,52 +418,52 @@ function get_keywords(processor::NoProcessor, docs::AbstractVector{<:AbstractStr
     docs
 end
 
-"""
-    get_keywords(processor::KeywordsProcessor, docs::AbstractVector{<:AbstractString};
-        verbose::Bool = true,
-        stemmer = nothing,
-        stopwords::Set{String} = Set(STOPWORDS),
-        return_keywords::Bool = false,
-        kwargs...)
+## """
+##     get_keywords(processor::KeywordsProcessor, docs::AbstractVector{<:AbstractString};
+##         verbose::Bool = true,
+##         stemmer = nothing,
+##         stopwords::Set{String} = Set(STOPWORDS),
+##         return_keywords::Bool = false,
+##         kwargs...)
 
-Generate a `DocumentTermMatrix` from a vector of `docs` using the provided `stemmer` and `stopwords`.
+## Generate a `DocumentTermMatrix` from a vector of `docs` using the provided `stemmer` and `stopwords`.
 
-# Arguments
-- `docs`: A vector of strings to be embedded.
-- `verbose`: A boolean flag for verbose output. Default is `true`.
-- `stemmer`: A stemmer to use for stemming. Default is `nothing`.
-- `stopwords`: A set of stopwords to remove. Default is `Set(STOPWORDS)`.
-- `return_keywords`: A boolean flag for returning the keywords. Default is `false`. Useful for query processing in search time.
-"""
-function get_keywords(processor::KeywordsProcessor, docs::AbstractVector{<:AbstractString};
-        verbose::Bool = true,
-        stemmer = nothing,
-        stopwords::Set{String} = Set(STOPWORDS),
-        return_keywords::Bool = false,
-        kwargs...)
-    ## check if extension is available
-    ext = Base.get_extension(PromptingTools, :RAGToolsExperimentalExt)
-    if isnothing(ext)
-        error("You need to also import LinearAlgebra and SparseArrays to use this function")
-    end
-    ext = Base.get_extension(PromptingTools, :SnowballPromptingToolsExt)
-    if isnothing(ext)
-        error("You need to also import Snowball.jl to use this function")
-    end
-    ## Preprocess text into tokens
-    stemmer = !isnothing(stemmer) ? stemmer : Snowball.Stemmer("english")
-    # Single-threaded as stemmer is not thread-safe
-    keywords = preprocess_tokens(docs, stemmer; stopwords, min_length = 3)
+## # Arguments
+## - `docs`: A vector of strings to be embedded.
+## - `verbose`: A boolean flag for verbose output. Default is `true`.
+## - `stemmer`: A stemmer to use for stemming. Default is `nothing`.
+## - `stopwords`: A set of stopwords to remove. Default is `Set(STOPWORDS)`.
+## - `return_keywords`: A boolean flag for returning the keywords. Default is `false`. Useful for query processing in search time.
+## """
+## function get_keywords(processor::KeywordsProcessor, docs::AbstractVector{<:AbstractString};
+##         verbose::Bool = true,
+##         stemmer = nothing,
+##         stopwords::Set{String} = Set(STOPWORDS),
+##         return_keywords::Bool = false,
+##         kwargs...)
+##     ## check if extension is available
+##     ext = Base.get_extension(PromptingTools, :RAGToolsExperimentalExt)
+##     if isnothing(ext)
+##         error("You need to also import LinearAlgebra and SparseArrays to use this function")
+##     end
+##     ext = Base.get_extension(PromptingTools, :SnowballPromptingToolsExt)
+##     if isnothing(ext)
+##         error("You need to also import Snowball.jl to use this function")
+##     end
+##     ## Preprocess text into tokens
+##     stemmer = !isnothing(stemmer) ? stemmer : Snowball.Stemmer("english")
+##     # Single-threaded as stemmer is not thread-safe
+##     keywords = preprocess_tokens(docs, stemmer; stopwords, min_length = 3)
 
-    ## Early exit if we only want keywords (search time)
-    return_keywords && return keywords
+##     ## Early exit if we only want keywords (search time)
+##     return_keywords && return keywords
 
-    ## Create DTM
-    dtm = document_term_matrix(keywords)
+##     ## Create DTM
+##     dtm = document_term_matrix(keywords)
 
-    verbose && @info "Done processing DocumentTermMatrix."
-    return dtm
-end
+##     verbose && @info "Done processing DocumentTermMatrix."
+##     return dtm
+## end
 
 ### Tag Extraction
 

--- a/src/Experimental/RAGTools/rag_interface.jl
+++ b/src/Experimental/RAGTools/rag_interface.jl
@@ -130,6 +130,8 @@ abstract type AbstractIndexBuilder <: AbstractIndexingMethod end
 abstract type AbstractChunker <: AbstractIndexingMethod end
 # For get_embeddings function
 abstract type AbstractEmbedder <: AbstractIndexingMethod end
+# For get_keywords function
+abstract type AbstractProcessor <: AbstractIndexingMethod end
 # For get_tags function
 abstract type AbstractTagger <: AbstractIndexingMethod end
 
@@ -251,6 +253,7 @@ abstract type AbstractAnnotationStyler end
 function build_index end
 function get_chunks end
 function get_embeddings end
+function get_keywords end
 function get_tags end
 # Sub-routing of get_tags, extended in ext/RAGToolsExperimentalExt.jl
 "Builds a matrix of tags and a vocabulary list. REQUIRES SparseArrays and LinearAlgebra packages to be loaded!!"

--- a/src/Experimental/RAGTools/utils.jl
+++ b/src/Experimental/RAGTools/utils.jl
@@ -280,8 +280,12 @@ end
 
 # Stub for string stemming to be extended in SnowballPromptingToolsExt
 function _stem(stemmer::Any, text::Any)
-    error(ArgumentError("Stemmer not found. Please install Snowball.jl"))
+    throw(ArgumentError("Stemmer not found. Please install Snowball.jl"))
 end
+function _unicode_normalize(text; kwargs...)
+    throw(ArgumentError("You need to import Unicode to use this function"))
+end
+
 """
     preprocess_tokens(text::AbstractString, stemmer=nothing; stopwords::Union{Nothing,Set{String}}=nothing, min_length::Int=3)
 
@@ -300,7 +304,7 @@ preprocess_tokens(text, stemmer; stopwords)
 function preprocess_tokens(text::AbstractString, stemmer = nothing;
         stopwords::Union{Nothing, Set{String}} = nothing, min_length::Int = 3)
     # Normalize Unicode and strip accents
-    text = Unicode.normalize(text; compose = true, casefold = true,
+    text = _unicode_normalize(text; compose = true, casefold = true,
         stripmark = true, stripignore = true, stripcc = true)
 
     # Remove numbers, punctuation, etc
@@ -312,7 +316,7 @@ function preprocess_tokens(text::AbstractString, stemmer = nothing;
 
     # Snowball stemmer
     if !isnothing(stemmer)
-        tokens = [Snowball.stem(stemmer, token) for token in tokens]
+        tokens = [_stem(stemmer, token) for token in tokens]
     end
 
     # Remove stopwords

--- a/test/Experimental/RAGTools/annotation.jl
+++ b/test/Experimental/RAGTools/annotation.jl
@@ -5,7 +5,8 @@ using PromptingTools.Experimental.RAGTools: AnnotatedNode, AbstractAnnotater,
                                             HTMLStyler,
                                             pprint, print_html
 using PromptingTools.Experimental.RAGTools: trigram_support!, add_node_metadata!,
-                                            annotate_support, RAGResult, text_to_trigrams
+                                            annotate_support, RAGResult, text_to_trigrams,
+                                            print_tree
 
 @testset "AnnotatedNode" begin
     # Test node creation with default values
@@ -282,8 +283,8 @@ end
     # Test annotating an answer that partially matches the context
     answer = "This is a test answer. It has multiple sentences."
     annotated_root = annotate_support(annotater, answer, context)
-    @test length(annotated_root.children) == 3 # One for each sentence + metadata
-    @test annotated_root.score≈0.42 atol=0.01
+    @test length(annotated_root.children) == 4 # One for each sentence + 2x metadata
+    @test annotated_root.score≈0.483 atol=0.01
     io = IOBuffer()
     pprint(io, annotated_root)
     output = String(take!(io))
@@ -395,7 +396,7 @@ end
 
     # print the HTML
     str = print_html(parent_node)
-    expected_output = "<div>This is a test <span style=\"color:magenta\">answer</span>. <span style=\"color:magenta\">It</span> has <span style=\"color:magenta\">multiple</span> <span style=\"color:blue\">sentences</span>.</div>"
+    expected_output = "<div>This is a test <span style=\"color:magenta\">answer</span>. It has <span style=\"color:magenta\">multiple</span> <span style=\"color:blue\">sentences</span>.</div>"
     @test str == expected_output
     # Test RAGResult overload
     rag = RAGResult(; context, final_answer = answer, question = "")

--- a/test/Experimental/RAGTools/runtests.jl
+++ b/test/Experimental/RAGTools/runtests.jl
@@ -4,6 +4,7 @@ using PromptingTools.Experimental.RAGTools
 using PromptingTools
 using PromptingTools.AbstractTrees
 const PT = PromptingTools
+using Snowball
 using JSON3, HTTP
 
 @testset "RAGTools" begin

--- a/test/Experimental/RAGTools/types.jl
+++ b/test/Experimental/RAGTools/types.jl
@@ -73,59 +73,59 @@ using PromptingTools: last_message, last_output
     @test ci1 == ci2
 end
 
-## @testset "DocumentTermMatrix" begin
-# Simple case
-documents = [["this", "is", "a", "test"],
-    ["this", "is", "another", "test"], ["foo", "bar", "baz"]]
-dtm = document_term_matrix(documents)
-@test size(dtm.tf) == (3, 8)
-@test Set(dtm.vocab) == Set(["a", "another", "bar", "baz", "foo", "is", "test", "this"])
-avgdl = 3.666666666666667
-@test all(dtm.doc_rel_length .≈ [4 / avgdl, 4 / avgdl, 3 / avgdl])
-@test length(dtm.idf) == 8
+@testset "DocumentTermMatrix" begin
+    # Simple case
+    documents = [["this", "is", "a", "test"],
+        ["this", "is", "another", "test"], ["foo", "bar", "baz"]]
+    dtm = document_term_matrix(documents)
+    @test size(dtm.tf) == (3, 8)
+    @test Set(dtm.vocab) == Set(["a", "another", "bar", "baz", "foo", "is", "test", "this"])
+    avgdl = 3.666666666666667
+    @test all(dtm.doc_rel_length .≈ [4 / avgdl, 4 / avgdl, 3 / avgdl])
+    @test length(dtm.idf) == 8
 
-# Edge case: single document
-documents = [["this", "is", "a", "test"]]
-dtm = document_term_matrix(documents)
-@test size(dtm.tf) == (1, 4)
-@test Set(dtm.vocab) == Set(["a", "is", "test", "this"])
-@test dtm.doc_rel_length == ones(1)
-@test length(dtm.idf) == 4
+    # Edge case: single document
+    documents = [["this", "is", "a", "test"]]
+    dtm = document_term_matrix(documents)
+    @test size(dtm.tf) == (1, 4)
+    @test Set(dtm.vocab) == Set(["a", "is", "test", "this"])
+    @test dtm.doc_rel_length == ones(1)
+    @test length(dtm.idf) == 4
 
-# Edge case: duplicate tokens
-documents = [["this", "is", "this", "test"],
-    ["this", "is", "another", "test"], ["this", "bar", "baz"]]
-dtm = document_term_matrix(documents)
-@test size(dtm.tf) == (3, 6)
-@test Set(dtm.vocab) == Set(["another", "bar", "baz", "is", "test", "this"])
-avgdl = 3.666666666666667
-@test all(dtm.doc_rel_length .≈ [4 / avgdl, 4 / avgdl, 3 / avgdl])
-@test length(dtm.idf) == 6
+    # Edge case: duplicate tokens
+    documents = [["this", "is", "this", "test"],
+        ["this", "is", "another", "test"], ["this", "bar", "baz"]]
+    dtm = document_term_matrix(documents)
+    @test size(dtm.tf) == (3, 6)
+    @test Set(dtm.vocab) == Set(["another", "bar", "baz", "is", "test", "this"])
+    avgdl = 3.666666666666667
+    @test all(dtm.doc_rel_length .≈ [4 / avgdl, 4 / avgdl, 3 / avgdl])
+    @test length(dtm.idf) == 6
 
-# Edge case: no tokens
-documents = [String[], String[], String[]]
-dtm = document_term_matrix(documents)
-@test size(dtm.tf) == (3, 0)
-@test isempty(dtm.vocab)
-@test isempty(dtm.vocab_lookup)
-@test isempty(dtm.idf)
-@test dtm.doc_rel_length == zeros(3)
+    # Edge case: no tokens
+    documents = [String[], String[], String[]]
+    dtm = document_term_matrix(documents)
+    @test size(dtm.tf) == (3, 0)
+    @test isempty(dtm.vocab)
+    @test isempty(dtm.vocab_lookup)
+    @test isempty(dtm.idf)
+    @test dtm.doc_rel_length == zeros(3)
 
-## Methods - hcat
-documents = [["this", "is", "a", "test"],
-    ["this", "is", "another", "test"], ["foo", "bar", "baz"]]
-dtm1 = document_term_matrix(documents)
-documents = [["this", "is", "a", "test"],
-    ["this", "is", "another", "test"], ["foo", "bar", "baz"]]
-dtm2 = document_term_matrix(documents)
-dtm = hcat(dtm1, dtm2)
-@test size(dtm.tf) == (6, 8)
-@test length(dtm.vocab) == 8
-@test length(dtm.idf) == 8
-@test isapprox(dtm.doc_rel_length,
-    [4 / 3.666666666666667, 4 / 3.666666666666667, 3 / 3.666666666666667,
-        4 / 3.666666666666667, 4 / 3.666666666666667, 3 / 3.666666666666667])
-## end
+    ## Methods - hcat
+    documents = [["this", "is", "a", "test"],
+        ["this", "is", "another", "test"], ["foo", "bar", "baz"]]
+    dtm1 = document_term_matrix(documents)
+    documents = [["this", "is", "a", "test"],
+        ["this", "is", "another", "test"], ["foo", "bar", "baz"]]
+    dtm2 = document_term_matrix(documents)
+    dtm = hcat(dtm1, dtm2)
+    @test size(dtm.tf) == (6, 8)
+    @test length(dtm.vocab) == 8
+    @test length(dtm.idf) == 8
+    @test isapprox(dtm.doc_rel_length,
+        [4 / 3.666666666666667, 4 / 3.666666666666667, 3 / 3.666666666666667,
+            4 / 3.666666666666667, 4 / 3.666666666666667, 3 / 3.666666666666667])
+end
 
 @testset "MultiIndex" begin
     # Test constructors/accessors

--- a/test/Experimental/RAGTools/utils.jl
+++ b/test/Experimental/RAGTools/utils.jl
@@ -1,5 +1,5 @@
 using PromptingTools.Experimental.RAGTools: _check_aiextract_capability,
-                                            merge_labeled_matrices
+                                            vcat_labeled_matrices, hcat_labeled_matrices
 using PromptingTools.Experimental.RAGTools: tokenize, trigrams, trigrams_hashed
 using PromptingTools.Experimental.RAGTools: token_with_boundaries, text_to_trigrams,
                                             text_to_trigrams_hashed
@@ -13,14 +13,14 @@ using PromptingTools.Experimental.RAGTools: pack_bits, unpack_bits
     @test_throws AssertionError _check_aiextract_capability("llama2")
 end
 
-@testset "merge_labeled_matrices" begin
+@testset "vcat_labeled_matrices" begin
     # Test with dense matrices and overlapping vocabulary
     mat1 = [1 2; 3 4]
     vocab1 = ["word1", "word2"]
     mat2 = [5 6; 7 8]
     vocab2 = ["word2", "word3"]
 
-    merged_mat, combined_vocab = merge_labeled_matrices(mat1, vocab1, mat2, vocab2)
+    merged_mat, combined_vocab = vcat_labeled_matrices(mat1, vocab1, mat2, vocab2)
 
     @test size(merged_mat) == (4, 3)
     @test combined_vocab == ["word1", "word2", "word3"]
@@ -32,7 +32,7 @@ end
     mat2 = sparse([3 0; 0 4])
     vocab2 = ["word3", "word4"]
 
-    merged_mat, combined_vocab = merge_labeled_matrices(mat1, vocab1, mat2, vocab2)
+    merged_mat, combined_vocab = vcat_labeled_matrices(mat1, vocab1, mat2, vocab2)
 
     @test size(merged_mat) == (4, 4)
     @test combined_vocab == ["word1", "word2", "word3", "word4"]
@@ -44,12 +44,51 @@ end
     mat2 = [5 6; 7 8]
     vocab2 = ["word2", "word3"]
 
-    merged_mat, combined_vocab = merge_labeled_matrices(mat1, vocab1, mat2, vocab2)
+    merged_mat, combined_vocab = vcat_labeled_matrices(mat1, vocab1, mat2, vocab2)
 
     @test eltype(merged_mat) == Float64
     @test size(merged_mat) == (4, 3)
     @test combined_vocab == ["word1", "word2", "word3"]
     @test merged_mat ≈ [1.0 2.0 0.0; 3.0 4.0 0.0; 0.0 5.0 6.0; 0.0 7.0 8.0]
+end
+
+@testset "hcat_labeled_matrices" begin
+    # Test with dense matrices and overlapping vocabulary
+    mat1 = [1 2; 3 4]
+    vocab1 = ["word1", "word2"]
+    mat2 = [5 6; 7 8]
+    vocab2 = ["word2", "word3"]
+
+    merged_mat, combined_vocab = hcat_labeled_matrices(mat1, vocab1, mat2, vocab2)
+
+    @test size(merged_mat) == (3, 4)
+    @test combined_vocab == ["word1", "word2", "word3"]
+    @test merged_mat == [1 2 0 0; 3 4 5 6; 0 0 7 8]
+
+    # Test with sparse matrices and disjoint vocabulary
+    mat1 = sparse([1 0; 0 2])
+    vocab1 = ["word1", "word2"]
+    mat2 = sparse([3 0; 0 4])
+    vocab2 = ["word3", "word4"]
+
+    merged_mat, combined_vocab = hcat_labeled_matrices(mat1, vocab1, mat2, vocab2)
+
+    @test size(merged_mat) == (4, 4)
+    @test combined_vocab == ["word1", "word2", "word3", "word4"]
+    @test merged_mat == sparse([1 0 0 0; 0 2 0 0; 0 0 3 0; 0 0 0 4])
+
+    # Test with different data types
+    mat1 = [1.0 2.0; 3.0 4.0]
+    vocab1 = ["word1", "word2"]
+    mat2 = [5 6; 7 8]
+    vocab2 = ["word2", "word3"]
+
+    merged_mat, combined_vocab = hcat_labeled_matrices(mat1, vocab1, mat2, vocab2)
+
+    @test eltype(merged_mat) == Float64
+    @test size(merged_mat) == (3, 4)
+    @test combined_vocab == ["word1", "word2", "word3"]
+    @test merged_mat ≈ [1.0 2.0 0.0 0.0; 3.0 4.0 5.0 6.0; 0.0 0.0 7.0 8.0]
 end
 
 ### Text-manipulation utilities

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Statistics
 using Dates: now
 using Test, Pkg, Random
 const PT = PromptingTools
+using Snowball
 using Aqua
 
 @testset "Code quality (Aqua.jl)" begin


### PR DESCRIPTION
- Added a keyword-based search similarity to RAGTools to serve both for baseline evaluation and for advanced performance (by having a hybrid index with both embeddings and BM25). See `?RT.KeywordsIndexer` and `?RT.BM25Similarity` for more information.