### PR TITLE
Update deps for 1.11 (REPL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.30.0]
+
+### Fixed
+- Fixed a bug on Julia 1.11 beta by adding REPL stdlib as a direct dependency.
+- Fixed too restrictive argument types for `RAGTools.build_tags` method.
+
 ## [0.29.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.29.0"
+version = "0.30.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -14,6 +14,7 @@ OpenAI = "e9f21f70-7185-4079-aca2-91159181367c"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -49,6 +50,7 @@ OpenAI = "0.9"
 Pkg = "<0.0.1, 1"
 PrecompileTools = "1"
 Preferences = "1"
+REPL = "<0.0.1, 1"
 Random = "<0.0.1, 1"
 SparseArrays = "<0.0.1, 1"
 Statistics = "<0.0.1, 1"

--- a/ext/RAGToolsExperimentalExt.jl
+++ b/ext/RAGToolsExperimentalExt.jl
@@ -18,16 +18,16 @@ end
 """
     RT.build_tags(
         tagger::RT.AbstractTagger, chunk_metadata::AbstractVector{
-            <:AbstractVector{String},
+            <:AbstractVector{<:AbstractString},
         })
 
 Builds a sparse matrix of tags and a vocabulary from the given vector of chunk metadata.
 """
 function RT.build_tags(
         tagger::RT.AbstractTagger, chunk_metadata::AbstractVector{
-            <:AbstractVector{String},
+            <:AbstractVector{<:AbstractString},
         })
-    tags_vocab_ = vcat(chunk_metadata...) |> unique |> sort
+    tags_vocab_ = vcat(chunk_metadata...) |> unique |> sort .|> String
     tags_vocab_index = Dict{String, Int}(t => i for (i, t) in enumerate(tags_vocab_))
     Is, Js = Int[], Int[]
     for i in eachindex(chunk_metadata)

--- a/src/PromptingTools.jl
+++ b/src/PromptingTools.jl
@@ -13,6 +13,8 @@ import Preferences
 using Preferences: @load_preference, @set_preferences!
 using PrecompileTools
 using Test, Pkg
+## Added REPL because it extends methods in Base.docs for extraction of docstrings
+using REPL
 
 # GLOBALS and Preferences are managed by Preferences.jl - see src/preferences.jl for details
 


### PR DESCRIPTION
- Fixed a bug on Julia 1.11 beta by adding REPL stdlib as a direct dependency.
- Fixed too restrictive argument types for `RAGTools.build_tags` method.

Partially tackles https://github.com/svilupp/PromptingTools.jl/issues/158, but it still requires upstream depency to be fixed on 1.11: https://github.com/JuliaWeb/HTTP.jl/issues/1167 