### PR TITLE
Update FlashRank to use only unique documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## Fixed
+
+## [0.32.0]
+
+## Updated
+- Changed behavior of `RAGTools.rerank(::FlashRanker,...)` to always dedupe input chunks (to reduce compute requirements).
+
 ## [0.31.1]
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Updated
 - Changed behavior of `RAGTools.rerank(::FlashRanker,...)` to always dedupe input chunks (to reduce compute requirements).
 
+## Fixed
+- Fixed a bug in verbose INFO log in `RAGTools.rerank(::FlashRanker,...)`.
+
 ## [0.31.1]
 
 ### Updated

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.31.1"
+version = "0.32.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/ext/FlashRankPromptingToolsExt.jl
+++ b/ext/FlashRankPromptingToolsExt.jl
@@ -62,8 +62,8 @@ function RT.rerank(
     documents = index[candidates, :chunks]
     @assert !(isempty(documents)) "The candidate chunks must not be empty for Cohere Reranker! Check the index IDs."
 
-    index_ids = candidates isa RT.MultiCandidateChunks ? candidates.index_ids :
-                candidates.index_id
+    is_multi_cand = candidates isa RT.MultiCandidateChunks
+    index_ids = is_multi_cand ? candidates.index_ids : candidates.index_id
     positions = candidates.positions
     ## Find unique only items
     if unique_chunks
@@ -71,7 +71,7 @@ function RT.rerank(
         unique_idxs = PT.unique_permutation(documents)
         documents = documents[unique_idxs]
         positions = positions[unique_idxs]
-        index_ids = index_ids[unique_idxs]
+        index_ids = is_multi_cand ? index_ids[unique_idxs] : index_ids
     end
 
     ## Run re-ranker
@@ -82,9 +82,9 @@ function RT.rerank(
     scores = result.scores
     positions = positions[result.positions]
 
-    verbose && @info "Reranking done in $(round(res.elapsed; digits=1)) seconds."
+    verbose && @info "Reranking done in $(round(result.elapsed; digits=1)) seconds."
 
-    return candidates isa RT.MultiCandidateChunks ?
+    return is_multi_cand ?
            RT.MultiCandidateChunks(index_ids[result.positions], positions, scores) :
            RT.CandidateChunks(index_ids, positions, scores)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -650,3 +650,12 @@ function auth_header(api_key::Union{Nothing, AbstractString};
         pushfirst!(headers, "x-api-key" => "$api_key")
     return headers
 end
+
+"""
+    unique_permutation(inputs::AbstractVector)
+
+Returns indices of unique items in a vector `inputs`. Access the unique values as `inputs[unique_permutation(inputs)]`.
+"""
+function unique_permutation(inputs::AbstractVector)
+    return unique(i -> inputs[i], eachindex(inputs))
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -5,7 +5,8 @@ using PromptingTools: _extract_handlebar_variables, call_cost, call_cost_alterna
 using PromptingTools: _string_to_vector, _encode_local_image
 using PromptingTools: DataMessage, AIMessage
 using PromptingTools: push_conversation!,
-                      resize_conversation!, @timeout, preview, pprint, auth_header
+                      resize_conversation!, @timeout, preview, pprint, auth_header,
+                      unique_permutation
 
 @testset "replace_words" begin
     words = ["Disney", "Snow White", "Mickey Mouse"]
@@ -370,4 +371,60 @@ end
         "Accept" => "application/json",
         "version" => "1.0"
     ]
+end
+
+@testset "unique_permutation" begin
+    # Test with an empty array
+    @test unique_permutation([]) == []
+
+    # Test with an array of integers
+    @test unique_permutation([1, 2, 3, 2, 1]) == [1, 2, 3]
+
+    # Test with an array of strings
+    @test unique_permutation(["apple", "banana", "apple", "orange"]) == [1, 2, 4]
+
+    # Test with repeated identical elements
+    @test unique_permutation([4, 4, 4, 4]) == [1]
+
+    # Test with non-consecutive duplicates
+    @test unique_permutation([1, 2, 3, 1, 2, 3, 1, 2, 3]) == [1, 2, 3]
+    @test unique_permutation([1, 2, 1, 2, 1, 2, 3, 1, 2, 3]) == [1, 2, 7]
+
+    # Test with an array of negative integers
+    @test unique_permutation([-1, -2, -3, -2, -1]) == [1, 2, 3]
+
+    # Test with an array of mixed positive and negative integers
+    @test unique_permutation([1, -1, 2, -2, 1, -1]) == [1, 2, 3, 4]
+
+    # Test with an array of floating point numbers
+    @test unique_permutation([1.1, 2.2, 3.3, 2.2, 1.1]) == [1, 2, 3]
+
+    # Test with an array of mixed integers and floating point numbers
+    @test unique_permutation([1, 2.0, 3, 2.0, 1]) == [1, 2, 3]
+
+    # Test with an array of very large integers
+    @test unique_permutation([10^10, 10^10, 10^12, 10^11, 10^12]) == [1, 3, 4]
+
+    # Test with an array of very small floating point numbers
+    @test unique_permutation([1e-10, 1e-10, 1e-12, 1e-11, 1e-12]) == [1, 3, 4]
+
+    # Test with an array of strings with different cases
+    @test unique_permutation(["Apple", "apple", "Banana", "banana", "Apple"]) ==
+          [1, 2, 3, 4]
+
+    # Test with an array of mixed data types
+    @test unique_permutation([1, "1", 2, "2", 1]) == [1, 2, 3, 4]
+
+    # Test with an array of complex numbers
+    @test unique_permutation([1 + 1im, 2 + 2im, 1 + 1im, 3 + 3im]) == [1, 2, 4]
+
+    # Test with an array of tuples
+    @test unique_permutation([(1, 2), (3, 4), (1, 2), (5, 6)]) == [1, 2, 4]
+
+    # Test with an array of arrays
+    @test unique_permutation([[1, 2], [3, 4], [5, 6], [1, 2]]) == [1, 2, 3]
+
+    # Test with an array of dictionaries
+    @test unique_permutation([
+        Dict(:a => 1), Dict(:b => 2), Dict(:a => 1), Dict(:c => 3)]) == [1, 2, 4]
 end


### PR DESCRIPTION
- Changed behavior of `RAGTools.rerank(::FlashRanker,...)` to always dedupe input chunks (to reduce compute requirements).