### PR TITLE
Add Anthropic Sonnet 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.33.0]
+
+### Added
+- Added registry record for Anthropic Claude 3.5 Sonnet with ID `claude-3-5-sonnet-20240620` (read the [blog post](https://www.anthropic.com/news/claude-3-5-sonnet)). Aliases "claude" and "claudes" have been linked to this latest Sonnet model.
+
 ## [0.32.0]
 
 ### Updated

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.32.0"
+version = "0.33.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -350,9 +350,9 @@ aliases = merge(
         "mistralc" => "codestral-latest",
         "codestral" => "codestral-latest",
         ## Default to Sonnet as a the medium offering
-        "claude" => "claude-3-sonnet-20240229",
+        "claude" => "claude-3-5-sonnet-20240620",
         "claudeo" => "claude-3-opus-20240229",
-        "claudes" => "claude-3-sonnet-20240229",
+        "claudes" => "claude-3-5-sonnet-20240620",
         "claudeh" => "claude-3-haiku-20240307",
         ## Groq
         "gllama3" => "llama3-8b-8192",
@@ -653,6 +653,11 @@ registry = Dict{String, ModelSpec}(
         9e-7,
         "Meta Llama3 70b from Mistral, hosted by Together.ai. For more information, see [models](https://docs.together.ai/docs/inference-models)."),
     ### Anthropic models
+    "claude-3-5-sonnet-20240620" => ModelSpec("claude-3-5-sonnet-20240620",
+        AnthropicSchema(),
+        3e-6,
+        1.5e-5,
+        "Anthropic's latest and strongest model Claude 3 Sonent 3.5. Max output 4096 tokens, 200K context. See details [here](https://docs.anthropic.com/claude/docs/models-overview)"),
     "claude-3-opus-20240229" => ModelSpec("claude-3-opus-20240229",
         AnthropicSchema(),
         1.5e-5,

--- a/test/llm_anthropic.jl
+++ b/test/llm_anthropic.jl
@@ -174,7 +174,7 @@ end
     @test msg == expected_output
     @test schema2.inputs.system == "Act as a helpful AI assistant"
     @test schema2.inputs.messages == [Dict("role" => "user", "content" => "Hello World")]
-    @test schema2.model_id == "claude-3-sonnet-20240229"
+    @test schema2.model_id == "claude-3-5-sonnet-20240620"
 end
 
 @testset "aiextract-Anthropic" begin


### PR DESCRIPTION
- Added registry record for Anthropic Claude 3.5 Sonnet with ID `claude-3-5-sonnet-20240620` (read the [blog post](https://www.anthropic.com/news/claude-3-5-sonnet)). Aliases "claude" and "claudes" have been linked to this latest Sonnet model.
