### PR TITLE
Add Reciprocal Rank Fusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.35.0]
+
+### Added
+- Added a utility function to RAGTools `reciprocal_rank_fusion`, as a principled way to merge multiple rankings. See `?RAGTools.Experimental.reciprocal_rank_fusion` for more information.
+
 ## [0.34.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.34.0"
+version = "0.35.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/Experimental/RAGTools/utils.jl
+++ b/src/Experimental/RAGTools/utils.jl
@@ -563,3 +563,32 @@ function unpack_bits(packed_matrix::AbstractMatrix{UInt64})
 
     return output_matrix
 end
+
+"""
+    reciprocal_rank_fusion(args...; k::Int=60)
+
+Merges multiple rankings and calculates the reciprocal rank score for each chunk (discounted by the inverse of the rank).
+
+# Example
+```julia
+positions1 = [1, 3, 5, 7, 9]
+positions2 = [2, 4, 6, 8, 10]
+positions3 = [2, 4, 6, 11, 12]
+
+merged_positions, scores = reciprocal_rank_fusion(positions1, positions2, positions3)
+```
+"""
+function reciprocal_rank_fusion(args...; k::Int = 60)
+    merged = Vector{Int}()
+    scores = Dict{Int, Float64}()
+
+    for positions in args
+        for (idx, pos) in enumerate(positions)
+            scores[pos] = get(scores, pos, 0.0) + 1.0 / (k + idx)
+        end
+    end
+
+    merged = [first(item) for item in sort(collect(scores), by = last, rev = true)]
+
+    return merged, scores
+end


### PR DESCRIPTION
- Added a utility function to RAGTools `reciprocal_rank_fusion`, as a principled way to merge multiple rankings. See `?RAGTools.Experimental.reciprocal_rank_fusion` for more information.
