### PR TITLE
Add AllTagFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a new tagging filter `RT.AllTagFilter` to `RT.find_tags`, which requires all tags to be present in a chunk.
 - Added an option in `RT.get_keywords` to set the minimum length of the keywords.
+- Added a new method for `reciprocal_rank_fusion` and utility for standardizing candidate chunk scores (`score_to_unit_scale`).
 
 ## [0.37.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.38.0]
+
+### Added
+- Added a new tagging filter `RT.AllTagFilter` to `RT.find_tags`, which requires all tags to be present in a chunk.
+- Added an option in `RT.get_keywords` to set the minimum length of the keywords.
+
 ## [0.37.1]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.37.1"
+version = "0.38.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/ext/SnowballPromptingToolsExt.jl
+++ b/ext/SnowballPromptingToolsExt.jl
@@ -17,6 +17,7 @@ RT._stem(stemmer::Snowball.Stemmer, text::AbstractString) = Snowball.stem(stemme
         stemmer = nothing,
         stopwords::Set{String} = Set(STOPWORDS),
         return_keywords::Bool = false,
+        min_length::Integer = 3,
         kwargs...)
 
 Generate a `DocumentTermMatrix` from a vector of `docs` using the provided `stemmer` and `stopwords`.
@@ -27,6 +28,7 @@ Generate a `DocumentTermMatrix` from a vector of `docs` using the provided `stem
 - `stemmer`: A stemmer to use for stemming. Default is `nothing`.
 - `stopwords`: A set of stopwords to remove. Default is `Set(STOPWORDS)`.
 - `return_keywords`: A boolean flag for returning the keywords. Default is `false`. Useful for query processing in search time.
+- `min_length`: The minimum length of the keywords. Default is `3`.
 """
 function RT.get_keywords(
         processor::RT.KeywordsProcessor, docs::AbstractVector{<:AbstractString};
@@ -34,6 +36,7 @@ function RT.get_keywords(
         stemmer = nothing,
         stopwords::Set{String} = Set(RT.STOPWORDS),
         return_keywords::Bool = false,
+        min_length::Integer = 3,
         kwargs...)
     ## check if extension is available
     ext = Base.get_extension(PromptingTools, :RAGToolsExperimentalExt)
@@ -47,7 +50,7 @@ function RT.get_keywords(
     ## Preprocess text into tokens
     stemmer = !isnothing(stemmer) ? stemmer : Snowball.Stemmer("english")
     # Single-threaded as stemmer is not thread-safe
-    keywords = RT.preprocess_tokens(docs, stemmer; stopwords, min_length = 3)
+    keywords = RT.preprocess_tokens(docs, stemmer; stopwords, min_length)
 
     ## Early exit if we only want keywords (search time)
     return_keywords && return keywords


### PR DESCRIPTION
- Added a new tagging filter `RT.AllTagFilter` to `RT.find_tags`, which requires all tags to be present in a chunk.
- Added an option in `RT.get_keywords` to set the minimum length of the keywords.