### PR TITLE
Add GPT-4o-mini + set as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.39.0]
+
+### Breaking Changes
+- Changed the default model for `ai*` chat functions (`PT.MODEL_CHAT`) from `gpt3t` to `gpt4om` (GPT-4o-mini). See the LLM-Leaderboard results and the release [blog post](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/).
+
+### Added
+- Added the new GPT-4o-mini to the model registry (alias `gpt4om`). It's the smallest and fastest model based on GPT4 that is cheaper than GPT3.5Turbo.
+
 ## [0.38.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.38.0"
+version = "0.39.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -124,7 +124,7 @@ function get_preferences(key::String)
 end
 
 ## Load up GLOBALS
-global MODEL_CHAT::String = @load_preference("MODEL_CHAT", default="gpt-3.5-turbo")
+global MODEL_CHAT::String = @load_preference("MODEL_CHAT", default="gpt-4o-mini")
 global MODEL_EMBEDDING::String = @load_preference("MODEL_EMBEDDING",
     default="text-embedding-3-small")
 global MODEL_IMAGE_GENERATION::String = @load_preference("MODEL_IMAGE_GENERATION",
@@ -325,6 +325,7 @@ aliases = merge(
     Dict("gpt3" => "gpt-3.5-turbo",
         "gpt4" => "gpt-4",
         "gpt4o" => "gpt-4o",
+        "gpt4om" => "gpt-4o-mini",
         "gpt4v" => "gpt-4-vision-preview", # 4v is for "4 vision"
         "gpt4t" => "gpt-4-turbo", # 4t is for "4 turbo"
         "gpt3t" => "gpt-3.5-turbo-0125", # 3t is for "3 turbo"
@@ -431,7 +432,17 @@ registry = Dict{String, ModelSpec}(
         OpenAISchema(),
         5e-6,
         1.5e-5,
-        "GPT-4 Omni, the latest GPT4 model that is faster and cheaper than GPT-4 Turbo is an updated version of GPT4 that is much faster and the cheaper to use. Currently points to version gpt-4o-2024-05-13."),
+        "GPT-4 Omni, the latest GPT4 model that is faster and cheaper than GPT-4 Turbo is an updated version of GPT4 that is much faster and the cheaper to use. Context of 128K, knowledge until October 2023. Currently points to version gpt-4o-2024-05-13."),
+    "gpt-4o-mini" => ModelSpec("gpt-4o-mini",
+        OpenAISchema(),
+        1.5e-7,
+        6e-7,
+        "GPT-4 Omni Mini, the smallest and fastest model based on GPT4 (and cheaper than GPT3.5Turbo)."),
+    "gpt-4o-mini-2024-07-18" => ModelSpec("gpt-4o-mini-2024-07-18",
+        OpenAISchema(),
+        1.5e-7,
+        6e-7,
+        "GPT-4 Omni Mini, the smallest and fastest model based on GPT4 (and cheaper than GPT3.5Turbo). Context of 128K, knowledge until October 2023. Currently points to version gpt-4o-2024-07-18."),
     "gpt-4-vision-preview" => ModelSpec(
         "gpt-4-vision-preview",
         OpenAISchema(),

--- a/test/llm_openai.jl
+++ b/test/llm_openai.jl
@@ -390,7 +390,7 @@ end
     @test schema1.inputs ==
           [Dict("role" => "system", "content" => "Act as a helpful AI assistant")
            Dict("role" => "user", "content" => "Hello World")]
-    @test schema1.model_id == "gpt-3.5-turbo"
+    @test schema1.model_id == "gpt-4o-mini"
 
     # Test different input combinations and different prompts
     schema2 = TestEchoOpenAISchema(; response, status = 200)


### PR DESCRIPTION
### Breaking Changes
- Changed the default model for `ai*` chat functions (`PT.MODEL_CHAT`) from `gpt3t` to `gpt4om` (GPT-4o-mini). See the LLM-Leaderboard results and the release [blog post](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/).

### Added
- Added the new GPT-4o-mini to the model registry (alias `gpt4om`). It's the smallest and fastest model based on GPT4 that is cheaper than GPT3.5Turbo.