### PR TITLE
Add Fireworks.ai llama3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.43.0]
+
+### Added
+- Added Llama 3.1 registry records for Fireworks.ai (alias `fllama3`, `fllama370`, `fllama3405` and `fls`, `flm`, `fll` for small/medium/large similar to the other providers).
+
 ## [0.42.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.42.0"
+version = "0.43.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -343,6 +343,12 @@ aliases = merge(
         ## f-mixtral -> Fireworks.ai Mixtral
         "fmixtral" => "accounts/fireworks/models/mixtral-8x7b-instruct",
         "firefunction" => "accounts/fireworks/models/firefunction-v1",
+        "fllama3" => "accounts/fireworks/models/llama-v3p1-8b-instruct",
+        "fllama370" => "accounts/fireworks/models/llama-v3p1-70b-instruct",
+        "fllama3405" => "accounts/fireworks/models/llama-v3p1-405b-instruct",
+        "fls" => "accounts/fireworks/models/llama-v3p1-8b-instruct", #s for small
+        "flm" => "accounts/fireworks/models/llama-v3p1-70b-instruct", #m for medium
+        "fll" => "accounts/fireworks/models/llama-v3p1-405b-instruct", #l for large
         ## t-mixtral -> Together.ai Mixtral
         "tmixtral" => "mistralai/Mixtral-8x7B-Instruct-v0.1",
         "tmixtral22" => "mistralai/Mixtral-8x22B-Instruct-v0.1",
@@ -657,6 +663,24 @@ registry = Dict{String, ModelSpec}(
         0.0, #unknown, expected to be the same as Mixtral
         0.0, #unknown, expected to be the same as Mixtral
         "Fireworks' open-source function calling model (fine-tuned Mixtral). Useful for `aiextract` calls. For more information, see [models](https://fireworks.ai/models/fireworks/firefunction-v1)."),
+    "accounts/fireworks/models/llama-v3p1-405b-instruct" => ModelSpec(
+        "accounts/fireworks/models/llama-v3p1-405b-instruct",
+        FireworksOpenAISchema(),
+        3e-6,
+        3e-6,
+        "Meta Llama 3.1 405b, hosted by Fireworks.ai. Context 131K tokens. For more information, see [models](https://fireworks.ai/models/fireworks/llama-v3p1-405b-instruct)."),
+    "accounts/fireworks/models/llama-v3p1-70b-instruct" => ModelSpec(
+        "accounts/fireworks/models/llama-v3p1-70b-instruct",
+        FireworksOpenAISchema(),
+        9e-7,
+        9e-7,
+        "Meta Llama 3.1 70b, hosted by Fireworks.ai. Context 131K tokens. For more information, see [models](https://fireworks.ai/models/fireworks/llama-v3p1-70b-instruct)."),
+    "accounts/fireworks/models/llama-v3p1-8b-instruct" => ModelSpec(
+        "accounts/fireworks/models/llama-v3p1-8b-instruct",
+        FireworksOpenAISchema(),
+        2e-7,
+        2e-7,
+        "Meta Llama 3.1 8b, hosted by Fireworks.ai. Context 131K tokens. For more information, see [models](https://fireworks.ai/models/fireworks/llama-v3p1-8b-instruct)."),
     ## Together AI
     "mistralai/Mixtral-8x7B-Instruct-v0.1" => ModelSpec(
         "mistralai/Mixtral-8x7B-Instruct-v0.1",


### PR DESCRIPTION
- Added Llama 3.1 registry records for Fireworks.ai (alias `fllama3`, `fllama370`, `fllama3405` and `fls`, `flm`, `fll` for small/medium/large similar to the other providers).