### PR TITLE
Fix `wrap_string` for long Unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.44.1]
+
+### Fixed
+- Fixed a bug where `wrap_string` would not correctly split very long Unicode words.
+
+
 ## [0.44.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.44.0"
+version = "0.44.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -231,8 +231,10 @@ function wrap_string(str::AbstractString,
                 current_line_length = 0
             end
             while word_length > text_width
-                write(output, word[1:(text_width - 1)], "-$newline")
-                word = word[text_width:end]
+                chop_idx = prevind(word, text_width, 1)
+                write(output, word[1:(chop_idx)], "-$newline")
+                start_idx = nextind(word, chop_idx, 1)
+                word = word[start_idx:end]
                 word_length -= text_width - 1
             end
         end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -102,6 +102,11 @@ end
     ## ensure newlines are not removed
     str = "This function\n will wrap\n words into lines"
     @test wrap_string(str, length(str)) == str
+    # Unicode testing
+    long_unicode_sentence = "Überraschenderweise ℕ𝕖𝕦𝕣𝕠𝕥𝕣𝕒𝕟𝕤𝕞𝕚𝕥𝕥𝕖𝕣 ℂ𝕙𝕣𝕪𝕤𝕒𝕟𝕥𝕙𝕖𝕞𝕦𝕞𝕤 𝕊𝕪𝕟𝕔𝕙𝕣𝕠𝕡𝕙𝕒𝕤𝕠𝕥𝕣𝕠𝕟 Ξ𝕩𝕥𝕣𝕒𝕠𝕣𝕕𝕚𝕟𝕒𝕚𝕣𝕖"
+    wrapped = wrap_string(long_unicode_sentence, 20)
+    @test all(length(line) ≤ 20 for line in split(wrapped, "\n"))
+    @test join(split(wrapped, "\n"), "") == replace(long_unicode_sentence, " " => "")
 end
 
 @testset "length_longest_common_subsequence" begin


### PR DESCRIPTION
- Fixed a bug where `wrap_string` would not correctly split very long Unicode words.