### PR TITLE
New GPT4o

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.46.0]
+
+### Added
+- Added a new model `gpt-4o-2024-08-06` to the model registry (alias `gpt4ol` with `l` for latest). It's the latest version of GPT4o, which is faster and cheaper than the previous version.
+
 ## [0.45.0]
 
 ### Breaking Change

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.45.0"
+version = "0.46.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -325,6 +325,7 @@ aliases = merge(
     Dict("gpt3" => "gpt-3.5-turbo",
         "gpt4" => "gpt-4",
         "gpt4o" => "gpt-4o",
+        "gpt4ol" => "gpt-4o-2024-08-06", #GPT4o latest
         "gpt4om" => "gpt-4o-mini",
         "gpt4v" => "gpt-4-vision-preview", # 4v is for "4 vision"
         "gpt4t" => "gpt-4-turbo", # 4t is for "4 turbo"
@@ -446,6 +447,11 @@ registry = Dict{String, ModelSpec}(
         5e-6,
         1.5e-5,
         "GPT-4 Omni, the latest GPT4 model that is faster and cheaper than GPT-4 Turbo is an updated version of GPT4 that is much faster and the cheaper to use."),
+    "gpt-4o-2024-08-06" => ModelSpec("gpt-4o-2024-08-06",
+        OpenAISchema(),
+        2.5e-6,
+        1.0e-5,
+        "GPT-4 Omni, the latest GPT4 model series that is faster and faster. This is the latest version from Aug-24, which is cheaper than May-24 version."),
     "gpt-4o" => ModelSpec("gpt-4o",
         OpenAISchema(),
         5e-6,


### PR DESCRIPTION
- Added a new model `gpt-4o-2024-08-06` to the model registry (alias `gpt4ol` with `l` for latest). It's the latest version of GPT4o, which is faster and cheaper than the previous version.

This version will automatically become the default GPT4o endpoint in 3 weeks.