### PR TITLE
Add assertion for empty docs in `get_embeddings`

### DIFF
--- a/src/Experimental/RAGTools/preparation.jl
+++ b/src/Experimental/RAGTools/preparation.jl
@@ -266,6 +266,8 @@ function get_embeddings(embedder::BatchEmbedder, docs::AbstractVector{<:Abstract
         target_batch_size_length::Int = 80_000,
         ntasks::Int = 4 * Threads.nthreads(),
         kwargs...)
+    @assert !isempty(docs) "The list of docs to get embeddings from should not be empty."
+
     ## check if extension is available
     ext = Base.get_extension(PromptingTools, :RAGToolsExperimentalExt)
     if isnothing(ext)
@@ -338,6 +340,8 @@ function get_embeddings(
         target_batch_size_length::Int = 80_000,
         ntasks::Int = 4 * Threads.nthreads(),
         kwargs...)
+    @assert !isempty(docs) "The list of docs to get embeddings from should not be empty."
+
     emb = get_embeddings(BatchEmbedder(), docs; verbose, model, truncate_dimension,
         cost_tracker, target_batch_size_length, ntasks, kwargs...)
     # This will return Matrix{Bool}, eg, map(>(0),emb)
@@ -387,6 +391,8 @@ function get_embeddings(
         target_batch_size_length::Int = 80_000,
         ntasks::Int = 4 * Threads.nthreads(),
         kwargs...)
+    @assert !isempty(docs) "The list of docs to get embeddings from should not be empty."
+
     emb = get_embeddings(BatchEmbedder(), docs; verbose, model, truncate_dimension,
         cost_tracker, target_batch_size_length, ntasks, kwargs...)
     # This will return Matrix{UInt64} to save space

--- a/test/Experimental/RAGTools/preparation.jl
+++ b/test/Experimental/RAGTools/preparation.jl
@@ -58,6 +58,11 @@ end
 end
 
 @testset "get_embeddings" begin
+    # docs should not be empty
+    @test_throws AssertionError get_embeddings(BatchEmbedder(), String[])
+    @test_throws AssertionError get_embeddings(BinaryBatchEmbedder(), String[])
+    @test_throws AssertionError get_embeddings(BitPackedBatchEmbedder(), String[])
+
     # corresponds to OpenAI API v1
     response1 = Dict(:data => [Dict(:embedding => ones(128, 2))],
         :usage => Dict(:total_tokens => 2, :prompt_tokens => 2, :completion_tokens => 0))


### PR DESCRIPTION
Giving empty docs to `get_embeddings` throws `ERROR: InexactError: trunc(Int64, NaN)`, which is not really suggestive. I added an assertion to make the error message clearer. I also added some unit tests.