### PR TITLE
Update Structured Extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.51.0]
 
 ### Added
-- Added more flexible structured extraction with `aiextract` -> now you can simply provide the field names and types without specifying the struct (in `aiextract`, provide the fields like `return_type = [:field_name => field_type]`). 
-- Added a way to attach field-level descriptions to the generated JSON schemas to better structured extraction (see `?update_schema_descriptions!`), which was not possible with structs.
+- Added more flexible structured extraction with `aiextract` -> now you can simply provide the field names and, optionally, their types without specifying the struct itself (in `aiextract`, provide the fields like `return_type = [:field_name => field_type]`). 
+- Added a way to attach field-level descriptions to the generated JSON schemas to better structured extraction (see `?update_schema_descriptions!` to see the syntax), which was not possible with struct-only extraction.
 
 ## [0.50.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.51.0]
+
+### Added
+- Added more flexible structured extraction with `aiextract` -> now you can simply provide the field names and types without specifying the struct (in `aiextract`, provide the fields like `return_type = [:field_name => field_type]`). 
+- Added a way to attach field-level descriptions to the generated JSON schemas to better structured extraction (see `?update_schema_descriptions!`), which was not possible with structs.
+
 ## [0.50.0]
 
 ### Breaking Changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.50.0"
+version = "0.51.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/Experimental/RAGTools/evaluation.jl
+++ b/src/Experimental/RAGTools/evaluation.jl
@@ -17,9 +17,9 @@ end
     context::AbstractString
     question::AbstractString
     answer::AbstractString
-    retrieval_score::Union{Number, Nothing} = nothing
+    retrieval_score::Union{Float64, Nothing} = nothing
     retrieval_rank::Union{Int, Nothing} = nothing
-    answer_score::Union{Number, Nothing} = nothing
+    answer_score::Union{Float64, Nothing} = nothing
     parameters::Dict{Symbol, Any} = Dict{Symbol, Any}()
 end
 

--- a/src/extraction.jl
+++ b/src/extraction.jl
@@ -349,13 +349,30 @@ end
 Generate a function call signature schema for a dynamically generated struct based on the provided fields.
 
 # Arguments
-- `fields::Vector{Union{Symbol, Pair{Symbol, Type}}}`: A vector of field names or pairs of field name and type, eg, `[:field1, :field2, :field3]` or `[:field1 => String, :field2 => Int, :field3 => Float64]`.
+- `fields::Vector{Union{Symbol, Pair{Symbol, Type}, Pair{Symbol, String}}}`: A vector of field names or pairs of field name and type or string description, eg, `[:field1, :field2, :field3]` or `[:field1 => String, :field2 => Int, :field3 => Float64]` or `[:field1 => String, :field1__description => "Field 1 has the name"]`.
 - `strict::Union{Nothing, Bool}`: Whether to enforce strict mode for the schema. Defaults to `nothing`.
 - `max_description_length::Int`: Maximum length for descriptions. Defaults to 200.
 
 # Returns a tuple of (schema, struct type)
 - `Dict{String, Any}`: A dictionary representing the function call signature schema.
 - `Type`: The struct type to create instance of the result.
+
+See also `generate_struct`, `aiextract`, `update_schema_descriptions!`.
+
+# Examples
+```julia
+schema, return_type = function_call_signature([:field1, :field2, :field3])
+```
+
+With the field types:
+```julia
+schema, return_type = function_call_signature([:field1 => String, :field2 => Int, :field3 => Float64])
+```
+
+And with the field descriptions:
+```julia
+schema, return_type = function_call_signature([:field1 => String, :field1__description => "Field 1 has the name"])
+```
 """
 function function_call_signature(fields::Vector;
         strict::Union{Nothing, Bool} = nothing, max_description_length::Int = 200)

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -439,3 +439,10 @@ function response_to_message(schema::AbstractPromptSchema,
         sample_id::Union{Nothing, Integer} = nothing) where {T}
     throw(ArgumentError("Response unwrapping not implemented for $(typeof(schema)) and $MSG"))
 end
+
+### For structured extraction
+# We can generate fields, they will all share this parent type
+abstract type AbstractExtractedData end
+Base.show(io::IO, x::AbstractExtractedData) = dump(io, x; maxdepth = 1)
+"Check if the object is an instance of `AbstractExtractedData`"
+isextracted(x) = x isa AbstractExtractedData

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -1136,13 +1136,18 @@ aiextract("I ate an apple",return_type=Fruit,api_kwargs=(;tool_choice="any"),mod
 # Notice two differences: 1) struct MUST have a docstring, 2) tool_choice is set explicitly set to "any"
 ```
 
-# Example of using a vector of field names with `aiextract`
+Example of using a vector of field names with `aiextract`
+```julia
 fields = [:location, :temperature => Float64, :condition => String]
 msg = aiextract("Extract the following information from the text: location, temperature, condition. Text: The weather in New York is sunny and 72.5 degrees Fahrenheit."; return_type = fields)
+```
 
-# It will be returned it a new generated type, which you can check with `PT.isextracted(msg.content) == true` to confirm the data has been extracted correctly.
+Or simply call `aiextract("some text"; return_type = [:reasoning,:answer])` to get a Chain of Thought reasoning for extraction task.
 
-# This new syntax also allows you to provide field-level descriptions, which will be passed to the model.
+It will be returned it a new generated type, which you can check with `PromptingTools.isextracted(msg.content) == true` to confirm the data has been extracted correctly.
+
+This new syntax also allows you to provide field-level descriptions, which will be passed to the model.
+```julia
 fields_with_descriptions = [
     :location,
     :temperature => Float64,
@@ -1151,6 +1156,7 @@ fields_with_descriptions = [
     :condition__description => "Current weather condition (e.g., sunny, rainy, cloudy)"
 ]
 msg = aiextract("The weather in New York is sunny and 72.5 degrees Fahrenheit."; return_type = fields_with_descriptions)
+```
 """
 function aiextract(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_TYPE;
         return_type::Union{Type, Vector},

--- a/test/Experimental/RAGTools/evaluation.jl
+++ b/test/Experimental/RAGTools/evaluation.jl
@@ -1,7 +1,8 @@
 using PromptingTools.Experimental.RAGTools: QAItem, QAEvalItem, QAEvalResult
 using PromptingTools.Experimental.RAGTools: score_retrieval_hit, score_retrieval_rank
 using PromptingTools.Experimental.RAGTools: build_qa_evals, run_qa_evals, chunks, sources
-using PromptingTools.Experimental.RAGTools: JudgeAllScores, Tag, MaybeTags
+using PromptingTools.Experimental.RAGTools: JudgeAllScores, Tag, MaybeTags, ChunkIndex,
+                                            RAGConfig, airag
 
 @testset "QAEvalItem" begin
     empty_qa = QAEvalItem()
@@ -75,7 +76,7 @@ end
 
 @testset "build_qa_evals" begin
     # test with a mock server
-    PORT = rand(10005:40001)
+    PORT = rand(10005:40010)
     PT.register_model!(; name = "mock-emb", schema = PT.CustomOpenAISchema())
     PT.register_model!(; name = "mock-meta", schema = PT.CustomOpenAISchema())
     PT.register_model!(; name = "mock-gen", schema = PT.CustomOpenAISchema())

--- a/test/extraction.jl
+++ b/test/extraction.jl
@@ -311,78 +311,6 @@ end
     @test !haskey(params["properties"]["email"], "null")
 end
 
-@testset "function_call_signature" begin
-    "Some docstring"
-    struct MyMeasurement2
-        age::Int
-        height::Union{Int, Nothing}
-        weight::Union{Nothing, Float64}
-    end
-    output, t = function_call_signature(MyMeasurement2)#|> JSON3.pretty
-    expected_output = Dict{String, Any}("name" => "MyMeasurement2_extractor",
-        "parameters" => Dict{String, Any}(
-            "properties" => Dict{String, Any}(
-                "height" => Dict{
-                    String,
-                    Any
-                }("type" => "integer"),
-                "weight" => Dict{String, Any}("type" => "number"),
-                "age" => Dict{String, Any}("type" => "integer")),
-            "required" => ["age"],
-            "type" => "object"),
-        "description" => "Some docstring\n")
-    @test output == expected_output
-
-    ## MaybeWraper name cleanup
-    schema, t = function_call_signature(MaybeExtract{MyMeasurement2})
-    @test schema["name"] == "MaybeExtractMyMeasurement2_extractor"
-
-    ## Test with strict = true
-
-    "Person's age, height, and weight."
-    struct MyMeasurement3
-        age::Int
-        height::Union{Int, Nothing}
-        weight::Union{Nothing, Float64}
-    end
-
-    # Test with strict = nothing (default behavior)
-    output_default, t = function_call_signature(MyMeasurement3)
-    @test !haskey(output_default, "strict")
-    @test output_default["name"] == "MyMeasurement3_extractor"
-    @test output_default["parameters"]["type"] == "object"
-    @test output_default["parameters"]["required"] == ["age"]
-    @test !haskey(output_default["parameters"], "additionalProperties")
-
-    # Test with strict =false
-    output_not_strict, t = function_call_signature(MyMeasurement3; strict = false)
-    @test haskey(output_not_strict, "strict")
-    @test output_not_strict["strict"] == false
-    @test output_not_strict["name"] == "MyMeasurement3_extractor"
-    @test output_not_strict["parameters"]["type"] == "object"
-    @test output_not_strict["parameters"]["required"] == ["age"]
-    @test !haskey(output_default["parameters"], "additionalProperties")
-
-    # Test with strict = true
-    output_strict, t = function_call_signature(MyMeasurement3; strict = true)
-    @test output_strict["strict"] == true
-    @test output_strict["name"] == "MyMeasurement3_extractor"
-    @test output_strict["parameters"]["type"] == "object"
-    @test Set(output_strict["parameters"]["required"]) == Set(["age", "height", "weight"])
-    @test output_strict["parameters"]["additionalProperties"] == false
-    @test output_strict["parameters"]["properties"]["height"]["type"] == ["integer", "null"]
-    @test output_strict["parameters"]["properties"]["weight"]["type"] == ["number", "null"]
-    @test output_strict["parameters"]["properties"]["age"]["type"] == "integer"
-
-    # Test with MaybeExtract wrapper
-    output_maybe, t = function_call_signature(MaybeExtract{MyMeasurement3}; strict = true)
-    @test output_maybe["name"] == "MaybeExtractMyMeasurement3_extractor"
-    @test output_maybe["parameters"]["properties"]["result"]["type"] == ["object", "null"]
-    @test output_maybe["parameters"]["properties"]["error"]["type"] == "boolean"
-    @test output_maybe["parameters"]["properties"]["message"]["type"] == ["string", "null"]
-    @test Set(output_maybe["parameters"]["required"]) == Set(["result", "error", "message"])
-end
-
 @testset "generate_struct" begin
     # Test with only field names
     fields = [:field1, :field2, :field3]
@@ -455,6 +383,77 @@ end
 end
 
 @testset "function_call_signature" begin
+    "Some docstring"
+    struct MyMeasurement2
+        age::Int
+        height::Union{Int, Nothing}
+        weight::Union{Nothing, Float64}
+    end
+    output, t = function_call_signature(MyMeasurement2)#|> JSON3.pretty
+    expected_output = Dict{String, Any}("name" => "MyMeasurement2_extractor",
+        "parameters" => Dict{String, Any}(
+            "properties" => Dict{String, Any}(
+                "height" => Dict{
+                    String,
+                    Any
+                }("type" => "integer"),
+                "weight" => Dict{String, Any}("type" => "number"),
+                "age" => Dict{String, Any}("type" => "integer")),
+            "required" => ["age"],
+            "type" => "object"),
+        "description" => "Some docstring\n")
+    @test output == expected_output
+
+    ## MaybeWraper name cleanup
+    schema, t = function_call_signature(MaybeExtract{MyMeasurement2})
+    @test schema["name"] == "MaybeExtractMyMeasurement2_extractor"
+
+    ## Test with strict = true
+
+    "Person's age, height, and weight."
+    struct MyMeasurement3
+        age::Int
+        height::Union{Int, Nothing}
+        weight::Union{Nothing, Float64}
+    end
+
+    # Test with strict = nothing (default behavior)
+    output_default, t = function_call_signature(MyMeasurement3)
+    @test !haskey(output_default, "strict")
+    @test output_default["name"] == "MyMeasurement3_extractor"
+    @test output_default["parameters"]["type"] == "object"
+    @test output_default["parameters"]["required"] == ["age"]
+    @test !haskey(output_default["parameters"], "additionalProperties")
+
+    # Test with strict =false
+    output_not_strict, t = function_call_signature(MyMeasurement3; strict = false)
+    @test haskey(output_not_strict, "strict")
+    @test output_not_strict["strict"] == false
+    @test output_not_strict["name"] == "MyMeasurement3_extractor"
+    @test output_not_strict["parameters"]["type"] == "object"
+    @test output_not_strict["parameters"]["required"] == ["age"]
+    @test !haskey(output_default["parameters"], "additionalProperties")
+
+    # Test with strict = true
+    output_strict, t = function_call_signature(MyMeasurement3; strict = true)
+    @test output_strict["strict"] == true
+    @test output_strict["name"] == "MyMeasurement3_extractor"
+    @test output_strict["parameters"]["type"] == "object"
+    @test Set(output_strict["parameters"]["required"]) == Set(["age", "height", "weight"])
+    @test output_strict["parameters"]["additionalProperties"] == false
+    @test output_strict["parameters"]["properties"]["height"]["type"] == ["integer", "null"]
+    @test output_strict["parameters"]["properties"]["weight"]["type"] == ["number", "null"]
+    @test output_strict["parameters"]["properties"]["age"]["type"] == "integer"
+
+    # Test with MaybeExtract wrapper
+    output_maybe, t = function_call_signature(MaybeExtract{MyMeasurement3}; strict = true)
+    @test output_maybe["name"] == "MaybeExtractMyMeasurement3_extractor"
+    @test output_maybe["parameters"]["properties"]["result"]["type"] == ["object", "null"]
+    @test output_maybe["parameters"]["properties"]["error"]["type"] == "boolean"
+    @test output_maybe["parameters"]["properties"]["message"]["type"] == ["string", "null"]
+    @test Set(output_maybe["parameters"]["required"]) == Set(["result", "error", "message"])
+
+    #### Test with generated structs and with descriptions
     # Test with simple fields
     fields = [:field1 => Int, :field2 => String]
     schema, datastructtype = function_call_signature(fields)

--- a/test/extraction.jl
+++ b/test/extraction.jl
@@ -1,6 +1,7 @@
 using PromptingTools: MaybeExtract, extract_docstring, ItemsExtract
 using PromptingTools: has_null_type, is_required_field, remove_null_types, to_json_schema
-using PromptingTools: function_call_signature, set_properties_strict!
+using PromptingTools: function_call_signature, set_properties_strict!,
+                      update_schema_descriptions!, generate_struct
 
 # TODO: check more edge cases like empty structs
 
@@ -380,4 +381,115 @@ end
     @test output_maybe["parameters"]["properties"]["error"]["type"] == "boolean"
     @test output_maybe["parameters"]["properties"]["message"]["type"] == ["string", "null"]
     @test Set(output_maybe["parameters"]["required"]) == Set(["result", "error", "message"])
+end
+
+@testset "generate_struct" begin
+    # Test with only field names
+    fields = [:field1, :field2, :field3]
+    struct_type, descriptions = generate_struct(fields)
+    @test fieldnames(struct_type) == (:field1, :field2, :field3)
+    @test descriptions == Dict{Symbol, String}()
+
+    # Test with field names and types
+    fields = [:field1 => Int, :field2 => String, :field3 => Float64]
+    struct_type, descriptions = generate_struct(fields)
+    @test fieldnames(struct_type) == (:field1, :field2, :field3)
+    @test fieldtypes(struct_type) == (Int, String, Float64)
+    @test descriptions == Dict{Symbol, String}()
+
+    # Test with field names, types, and descriptions
+    fields = [:field1 => Int, :field2 => String, :field3 => Float64,
+        :field1__description => "Field 1 description",
+        :field2__description => "Field 2 description"]
+    struct_type, descriptions = generate_struct(fields)
+    @test fieldnames(struct_type) == (:field1, :field2, :field3)
+    @test fieldtypes(struct_type) == (Int, String, Float64)
+    @test descriptions ==
+          Dict(:field1 => "Field 1 description", :field2 => "Field 2 description")
+
+    # Test with invalid field specification
+    fields = [:field1 => Int, :field2 => :InvalidType]
+    @test_throws ErrorException generate_struct(fields)
+end
+
+@testset "update_schema_descriptions!" begin
+    # Test with empty descriptions
+    schema = Dict("parameters" => Dict("properties" => Dict("field1" => Dict("type" => "string"))))
+    descriptions = Dict{Symbol, String}()
+    updated_schema = update_schema_descriptions!(schema, descriptions)
+    @test !haskey(updated_schema["parameters"]["properties"]["field1"], "description")
+
+    # Test with descriptions provided
+    schema = Dict("parameters" => Dict("properties" => Dict("field1" => Dict("type" => "string"))))
+    descriptions = Dict(:field1 => "Field 1 description")
+    updated_schema = update_schema_descriptions!(schema, descriptions)
+    @test updated_schema["parameters"]["properties"]["field1"]["description"] ==
+          "Field 1 description"
+
+    # Test with max_description_length
+    schema = Dict("parameters" => Dict("properties" => Dict("field1" => Dict("type" => "string"))))
+    descriptions = Dict(:field1 => "Field 1 description is very long and should be truncated")
+    updated_schema = update_schema_descriptions!(
+        schema, descriptions; max_description_length = 10)
+    @test updated_schema["parameters"]["properties"]["field1"]["description"] ==
+          "Field 1 de"
+
+    # Test with multiple fields
+    schema = Dict("parameters" => Dict("properties" => Dict(
+        "field1" => Dict("type" => "string"), "field2" => Dict("type" => "integer"))))
+    descriptions = Dict(:field1 => "Field 1 description", :field2 => "Field 2 description")
+    updated_schema = update_schema_descriptions!(schema, descriptions)
+    @test updated_schema["parameters"]["properties"]["field1"]["description"] ==
+          "Field 1 description"
+    @test updated_schema["parameters"]["properties"]["field2"]["description"] ==
+          "Field 2 description"
+
+    # Test with missing field in descriptions
+    schema = Dict("parameters" => Dict("properties" => Dict(
+        "field1" => Dict("type" => "string"), "field2" => Dict("type" => "integer"))))
+    descriptions = Dict(:field1 => "Field 1 description")
+    updated_schema = update_schema_descriptions!(schema, descriptions)
+    @test updated_schema["parameters"]["properties"]["field1"]["description"] ==
+          "Field 1 description"
+    @test !haskey(updated_schema["parameters"]["properties"]["field2"], "description")
+end
+
+@testset "function_call_signature" begin
+    # Test with simple fields
+    fields = [:field1 => Int, :field2 => String]
+    schema, datastructtype = function_call_signature(fields)
+    @test haskey(schema, "name")
+    @test haskey(schema, "parameters")
+    @test haskey(schema["parameters"], "properties")
+    @test haskey(schema["parameters"]["properties"], "field1")
+    @test haskey(schema["parameters"]["properties"], "field2")
+    @test schema["parameters"]["properties"]["field1"]["type"] == "integer"
+    @test schema["parameters"]["properties"]["field2"]["type"] == "string"
+
+    # Test with strict mode
+    fields = [:field1 => Int, :field2 => String]
+    schema, datastructtype = function_call_signature(fields; strict = true)
+    @test schema["strict"] == true
+
+    # Test with max_description_length
+    fields = [:field1 => Int, :field2 => String]
+    schema, datastructtype = function_call_signature(fields; max_description_length = 10)
+    @test haskey(schema, "name")
+    @test haskey(schema, "parameters")
+    @test haskey(schema["parameters"], "properties")
+    @test haskey(schema["parameters"]["properties"], "field1")
+    @test haskey(schema["parameters"]["properties"], "field2")
+    @test schema["parameters"]["properties"]["field1"]["type"] == "integer"
+    @test schema["parameters"]["properties"]["field2"]["type"] == "string"
+
+    # Test with empty fields
+    fields = []
+    schema, datastructtype = function_call_signature(fields)
+    @test haskey(schema, "name")
+    @test haskey(schema, "parameters")
+    @test !haskey(schema["parameters"], "properties")
+
+    # Test with invalid field specification
+    fields = [:field1 => Int, :field2 => "InvalidType"]
+    @test_throws ErrorException function_call_signature(fields)
 end

--- a/test/llm_openai.jl
+++ b/test/llm_openai.jl
@@ -4,7 +4,8 @@ using PromptingTools: UserMessage, UserMessageWithImages, DataMessage
 using PromptingTools: CustomProvider,
                       CustomOpenAISchema, MistralOpenAISchema, MODEL_EMBEDDING,
                       MODEL_IMAGE_GENERATION
-using PromptingTools: encode_choices, decode_choices, response_to_message, call_cost
+using PromptingTools: encode_choices, decode_choices, response_to_message, call_cost,
+                      isextracted
 
 @testset "render-OpenAI" begin
     schema = OpenAISchema()
@@ -628,6 +629,14 @@ end
         api_kwargs = (; temperature = 0, n = 2))
     @test msg.content == RandomType1235(1)
     @test msg.log_prob ≈ -0.9
+
+    ## Test with field descriptions
+    fields = [:x => Int, :x__description => "Field 1 description"]
+    msg = aiextract(schema1, "Extract number 1"; return_type = fields,
+        model = "gpt4",
+        api_kwargs = (; temperature = 0, n = 2))
+    @test isextracted(msg.content)
+    @test msg.content.x == 1
 
     ## Test multiple samples -- mock_choice is less probable
     mock_choice2 = Dict(


### PR DESCRIPTION
- Added more flexible structured extraction with `aiextract` -> now you can simply provide the field names and, optionally, their types without specifying the struct itself (in `aiextract`, provide the fields like `return_type = [:field_name => field_type]`). 
- Added a way to attach field-level descriptions to the generated JSON schemas to better structured extraction (see `?update_schema_descriptions!` to see the syntax), which was not possible with struct-only extraction.

Example:
```julia
fields_with_descriptions = [
    :location,
    :temperature => Float64,
    :temperature__description => "Temperature in degrees Fahrenheit",
    :condition => String,
    :condition__description => "Current weather condition (e.g., sunny, rainy, cloudy)"
]
msg = aiextract("The weather in New York is sunny and 72.5 degrees Fahrenheit."; return_type = fields_with_descriptions)
```

Or simply `aiextract("some text"; return_type=[:reasoning, :answer])` for a quick chain of thought extraction