### PR TITLE
OpenAI JSON mode extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.55.0]
+
+### Added
+- Added support for OpenAI's JSON mode for `aiextract` (just provide kwarg `json_mode=true`). Reference [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs).
+
+### Fixed
+- Fixed a bug in `aiclassify` for the OpenAI GPT4o models that have a different tokenizer. Unknown model IDs will throw an error.
+
 ## [0.54.0]
 
 ### Updated

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.54.0"
+version = "0.55.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -677,7 +677,7 @@ function aiembed(prompt_schema::AbstractOpenAISchema,
 end
 
 "Token IDs for GPT3.5 and GPT4 from https://platform.openai.com/tokenizer"
-const OPENAI_TOKEN_IDS = Dict("true" => 837,
+const OPENAI_TOKEN_IDS_GPT35_GPT4 = Dict("true" => 837,
     "false" => 905,
     "unknown" => 9987,
     "other" => 1023,
@@ -723,50 +723,64 @@ const OPENAI_TOKEN_IDS = Dict("true" => 837,
     "40" => 1272
 )
 # GPT-4o token IDs as per tiktoken
-# "true": 3309,
-# "false": 7556,
-# "unknown": 33936,
-# "other": 2141,
-# "1": 16,
-# "2": 17,
-# "3": 18,
-# "4": 19,
-# "5": 20,
-# "6": 21,
-# "7": 22,
-# "8": 23,
-# "9": 24,
-# "10": 702,
-# "11": 994,
-# "12": 899,
-# "13": 1311,
-# "14": 1265,
-# "15": 1055,
-# "16": 1125,
-# "17": 1422,
-# "18": 1157,
-# "19": 858,
-# "20": 455,
-# "21": 2040,
-# "22": 1709,
-# "23": 1860,
-# "24": 1494,
-# "25": 1161,
-# "26": 2109,
-# "27": 2092,
-# "28": 2029,
-# "29": 2270,
-# "30": 1130,
-# "31": 2911,
-# "32": 1398,
-# "33": 2546,
-# "34": 3020,
-# "35": 2467,
-# "36": 2636,
-# "37": 2991,
-# "38": 3150,
-# "39": 3255,
-# "40": 1723,
+const OPENAI_TOKEN_IDS_GPT4O = Dict(
+    "true" => 3309,
+    "false" => 7556,
+    "unknown" => 33936,
+    "other" => 2141,
+    "1" => 16,
+    "2" => 17,
+    "3" => 18,
+    "4" => 19,
+    "5" => 20,
+    "6" => 21,
+    "7" => 22,
+    "8" => 23,
+    "9" => 24,
+    "10" => 702,
+    "11" => 994,
+    "12" => 899,
+    "13" => 1311,
+    "14" => 1265,
+    "15" => 1055,
+    "16" => 1125,
+    "17" => 1422,
+    "18" => 1157,
+    "19" => 858,
+    "20" => 455,
+    "21" => 2040,
+    "22" => 1709,
+    "23" => 1860,
+    "24" => 1494,
+    "25" => 1161,
+    "26" => 2109,
+    "27" => 2092,
+    "28" => 2029,
+    "29" => 2270,
+    "30" => 1130,
+    "31" => 2911,
+    "32" => 1398,
+    "33" => 2546,
+    "34" => 3020,
+    "35" => 2467,
+    "36" => 2636,
+    "37" => 2991,
+    "38" => 3150,
+    "39" => 3255,
+    "40" => 1723)
+
+function pick_tokenizer(model::AbstractString)
+    global OPENAI_TOKEN_IDS_GPT35_GPT4, OPENAI_TOKEN_IDS_GPT4O
+    OPENAI_TOKEN_IDS = if model == "gpt-4" || startswith(model, "gpt-3.5") ||
+                          startswith(model, "gpt-4-")
+        OPENAI_TOKEN_IDS_GPT35_GPT4
+    elseif startswith(model, "gpt-4o")
+        OPENAI_TOKEN_IDS_GPT4O
+    else
+        throw(ArgumentError("Model $model is not supported by `encode_choices`. We don't have token IDs for it."))
+    end
+    return OPENAI_TOKEN_IDS
+end
 
 """
     encode_choices(schema::OpenAISchema, choices::AbstractVector{<:AbstractString}; kwargs...)
@@ -810,8 +824,9 @@ logit_bias # Output: Dict(16 => 100, 17 => 100, 18 => 100)
 """
 function encode_choices(schema::OpenAISchema,
         choices::AbstractVector{<:AbstractString};
+        model::AbstractString,
         kwargs...)
-    global OPENAI_TOKEN_IDS
+    OPENAI_TOKEN_IDS = pick_tokenizer(model)
     ## if all choices are in the dictionary, use the dictionary
     if all(Base.Fix1(haskey, OPENAI_TOKEN_IDS), choices)
         choices_prompt = ["$c for \"$c\"" for c in choices]
@@ -828,18 +843,19 @@ function encode_choices(schema::OpenAISchema,
 end
 function encode_choices(schema::OpenAISchema,
         choices::AbstractVector{T};
+        model::AbstractString,
         kwargs...) where {T <: Tuple{<:AbstractString, <:AbstractString}}
-    global OPENAI_TOKEN_IDS
+    OPENAI_TOKEN_IDS = pick_tokenizer(model)
     ## if all choices are in the dictionary, use the dictionary
     if all(Base.Fix1(haskey, OPENAI_TOKEN_IDS), first.(choices))
         choices_prompt = ["$c for \"$desc\"" for (c, desc) in choices]
         logit_bias = Dict(OPENAI_TOKEN_IDS[c] => 100 for (c, desc) in choices)
-    elseif length(choices) <= 20
+    elseif length(choices) <= 40
         ## encode choices to IDs 1..20
         choices_prompt = ["$(i). \"$c\" for $desc" for (i, (c, desc)) in enumerate(choices)]
         logit_bias = Dict(OPENAI_TOKEN_IDS[string(i)] => 100 for i in 1:length(choices))
     else
-        throw(ArgumentError("The number of choices must be less than or equal to 20."))
+        throw(ArgumentError("The number of choices must be less than or equal to 40."))
     end
 
     return join(choices_prompt, "\n"), logit_bias, first.(choices)
@@ -857,7 +873,9 @@ function decode_choices(schema::TestEchoOpenAISchema,
     return decode_choices(OpenAISchema(), choices, conv; kwargs...)
 end
 
-function decode_choices(schema::OpenAISchema, choices, conv::AbstractVector; kwargs...)
+function decode_choices(schema::OpenAISchema, choices, conv::AbstractVector;
+        model::AbstractString,
+        kwargs...)
     if length(conv) > 0 && last(conv) isa AIMessage && hasproperty(last(conv), :run_id)
         ## if it is a multi-sample response, 
         ## Remember its run ID and convert all samples in that run
@@ -865,7 +883,7 @@ function decode_choices(schema::OpenAISchema, choices, conv::AbstractVector; kwa
         for i in eachindex(conv)
             msg = conv[i]
             if isaimessage(msg) && msg.run_id == run_id
-                conv[i] = decode_choices(schema, choices, msg)
+                conv[i] = decode_choices(schema, choices, msg; model)
             end
         end
     end
@@ -875,7 +893,7 @@ end
 """
     decode_choices(schema::OpenAISchema,
         choices::AbstractVector{<:AbstractString},
-        msg::AIMessage; kwargs...)
+        msg::AIMessage; model::AbstractString, kwargs...)
 
 Decodes the underlying AIMessage against the original choices to lookup what the category name was.
 
@@ -883,8 +901,8 @@ If it fails, it will return `msg.content == nothing`
 """
 function decode_choices(schema::OpenAISchema,
         choices::AbstractVector{<:AbstractString},
-        msg::AIMessage; kwargs...)
-    global OPENAI_TOKEN_IDS
+        msg::AIMessage; model::AbstractString, kwargs...)
+    OPENAI_TOKEN_IDS = pick_tokenizer(model)
     parsed_digit = tryparse(Int, strip(msg.content))
     if !isnothing(parsed_digit) && haskey(OPENAI_TOKEN_IDS, strip(msg.content))
         ## It's encoded
@@ -903,6 +921,7 @@ end
 """
     aiclassify(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_TYPE;
         choices::AbstractVector{T} = ["true", "false", "unknown"],
+        model::AbstractString = MODEL_CHAT,
         api_kwargs::NamedTuple = NamedTuple(),
         kwargs...) where {T <: Union{AbstractString, Tuple{<:AbstractString, <:AbstractString}}}
 
@@ -921,6 +940,9 @@ It uses Logit bias trick and limits the output to 1 token to force the model to 
 - `prompt_schema::AbstractOpenAISchema`: The schema for the prompt.
 - `prompt`: The prompt/statement to classify if it's a `String`. If it's a `Symbol`, it is expanded as a template via `render(schema,template)`. Eg, templates `:JudgeIsItTrue` or `:InputClassifier`
 - `choices::AbstractVector{T}`: The choices to be classified into. It can be a vector of strings or a vector of tuples, where the first element is the choice and the second is the description.
+- `model::AbstractString = MODEL_CHAT`: The model to use for classification. Can be an alias corresponding to a model ID defined in `MODEL_ALIASES`.
+- `api_kwargs::NamedTuple = NamedTuple()`: Additional keyword arguments for the API call.
+- `kwargs`: Additional keyword arguments for the prompt template.
 
 # Example
 
@@ -978,20 +1000,23 @@ aiclassify(:JudgeIsItTrue;
 """
 function aiclassify(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_TYPE;
         choices::AbstractVector{T} = ["true", "false", "unknown"],
+        model::AbstractString = MODEL_CHAT,
         api_kwargs::NamedTuple = NamedTuple(),
         kwargs...) where {T <:
                           Union{AbstractString, Tuple{<:AbstractString, <:AbstractString}}}
     ## Encode the choices and the corresponding prompt 
-    ## TODO: maybe check the model provided as well?
-    choices_prompt, logit_bias, decode_ids = encode_choices(prompt_schema, choices)
+    model_id = get(MODEL_ALIASES, model, model)
+    choices_prompt, logit_bias, decode_ids = encode_choices(
+        prompt_schema, choices; model = model_id)
     ## We want only 1 token
     api_kwargs = merge(api_kwargs, (; logit_bias, max_tokens = 1, temperature = 0))
     msg_or_conv = aigenerate(prompt_schema,
         prompt;
         choices = choices_prompt,
+        model = model_id,
         api_kwargs,
         kwargs...)
-    return decode_choices(prompt_schema, decode_ids, msg_or_conv)
+    return decode_choices(prompt_schema, decode_ids, msg_or_conv; model = model_id)
 end
 
 function response_to_message(schema::AbstractOpenAISchema,
@@ -1435,7 +1460,6 @@ function aiscan(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_TYPE
             conv_rendered;
             http_kwargs,
             api_kwargs...)
-        @info JSON3.pretty(r.response)
         ## Process one of more samples returned
         msg = if length(r.response[:choices]) > 1
             run_id = Int(rand(Int32)) # remember one run ID

--- a/test/llm_interface.jl
+++ b/test/llm_interface.jl
@@ -27,7 +27,8 @@ using PromptingTools: response_to_message, AbstractPromptSchema
     @test msg == expected_output
 
     ### AIClassify
-    msg = aiclassify("Hello World"; choices = ["true", "false", "unknown"], model = "xyz")
+    msg = aiclassify(
+        "Hello World"; choices = ["true", "false", "unknown"], model = "gpt-4o-made-up-model")
     expected_output = AIMessage(;
         content = nothing,
         status = 200,


### PR DESCRIPTION
### Added
- Added support for OpenAI's JSON mode for `aiextract` (just provide kwarg `json_mode=true`). Reference [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs).

### Fixed
- Fixed a bug in `aiclassify` for the OpenAI GPT4o models that have a different tokenizer. Unknown model IDs will throw an error.
