### PR TITLE
OpenRouter support, new OpenAI o1 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new OpenRouter hosted models to the model registry (prefixed with `or`): `oro1` (OpenAI's o1-preview), `oro1m` (OpenAI's o1-mini), `orcop` (Cohere's command-r-plus), `orco` (Cohere's command-r). The `or` prefix is to avoid conflicts with existing models and OpenAI's aliases, then the goal is to provide 2 letters for each model and 1 letter for additional qualifier (eg, "p" for plus, "m" for mini) -> `orcop` (OpenRouter cohere's COmmand-r-Plus).
 
 ### Updated
-- Updated FAQ with instructions how to access new OpenAI o1 models via OpenRouter.
+- Updated FAQ with instructions on how to access new OpenAI o1 models via OpenRouter.
 - Updated FAQ with instructions on how to add custom APIs (with an example `examples/adding_custom_API.jl`).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for OpenAI's JSON mode for `aiextract` (just provide kwarg `json_mode=true`). Reference [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs).
 - Added support for OpenRouter's API (you must set ENV `OPENROUTER_API_KEY`) to provide access to more models like Cohere Command R+ and OpenAI's o1 series. Reference [OpenRouter](https://openrouter.ai/).
+- Added new OpenRouter hosted models to the model registry (prefixed with `or`): `oro1` (OpenAI's o1-preview), `oro1m` (OpenAI's o1-mini), `orcop` (Cohere's command-r-plus), `orco` (Cohere's command-r). The `or` prefix is to avoid conflicts with existing models and OpenAI's aliases, then the goal is to provide 2 letters for each model and 1 letter for additional qualifier (eg, "p" for plus, "m" for mini) -> `orcop` (OpenRouter cohere's COmmand-r-Plus).
+
+### Updated
+- Updated FAQ with instructions how to access new OpenAI o1 models via OpenRouter.
+- Updated FAQ with instructions on how to add custom APIs (with an example `examples/adding_custom_API.jl`).
 
 ### Fixed
 - Fixed a bug in `aiclassify` for the OpenAI GPT4o models that have a different tokenizer. Unknown model IDs will throw an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for OpenAI's JSON mode for `aiextract` (just provide kwarg `json_mode=true`). Reference [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs).
+- Added support for OpenRouter's API (you must set ENV `OPENROUTER_API_KEY`) to provide access to more models like Cohere Command R+ and OpenAI's o1 series. Reference [OpenRouter](https://openrouter.ai/).
 
 ### Fixed
 - Fixed a bug in `aiclassify` for the OpenAI GPT4o models that have a different tokenizer. Unknown model IDs will throw an error.

--- a/examples/adding_custom_API.jl
+++ b/examples/adding_custom_API.jl
@@ -1,0 +1,85 @@
+# Example of custom API integration, eg, custom enterprise proxy with special headers
+#
+# This should NOT be necessary unless you have a private LLM / private proxy with specialized API structure and headers.
+# For most new APIs, you should check out the FAQ on "Using Custom API Providers like Azure or Databricks"
+# DatabricksOpenAISchema is a good example how to do simple API integration.
+#
+# For heavily customized APIs, follow the example below. Again, do this only if you have no other choice!!
+
+# We will need to provide a custom "provider" and custom methods for `OpenAI.jl` to override how it builds the AUTH headers and URL.
+
+using PromptingTools
+const PT = PromptingTools
+using HTTP
+using JSON3
+
+## OpenAI.jl work
+# Define a custom provider for OpenAI to override the default behavior
+abstract type MyCustomProvider <: PT.AbstractCustomProvider end
+
+@kwdef struct MyModelProvider <: MyCustomProvider
+    api_key::String = ""
+    base_url::String = "https://api.example.com/v1239123/modelxyz/completions_that_are_not_standard"
+    api_version::String = ""
+end
+
+# Tell OpenAI not to use "api" (=endpoints)
+function PT.OpenAI.build_url(provider::MyCustomProvider, api::AbstractString = "")
+    string(provider.base_url)
+end
+
+function PT.OpenAI.auth_header(
+        provider::MyCustomProvider, api_key::AbstractString = provider.api_key)
+    ## Note this DOES NOT have any Basic Auth! Assumes you use something custom
+    ["Content-Type" => "application/json", "Extra-custom-authorization" => api_key]
+end
+
+## PromptingTools.jl work
+# Define a custom schema
+struct MyCustomSchema <: PT.AbstractOpenAISchema end
+
+# Implement create_chat for the custom schema
+function PT.OpenAI.create_chat(schema::MyCustomSchema,
+        api_key::AbstractString,
+        model::AbstractString,
+        conversation;
+        url::String = "",
+        ## Add any required kwargs here, APIs may have different requirements
+        max_tokens::Int = 2048,
+        kwargs...)
+    ## Depending on your needs, you can get api_key from ENV variable!!
+    ## Eg, api_key = get(ENV, "CUSTOM_API_KEY", "")
+    provider = MyModelProvider(; api_key, base_url = url)
+
+    ## The first arg will be ignored, doesn't matter what you put there
+    PT.OpenAI.openai_request("ignore-me", provider;
+        method = "POST",
+        messages = conversation,
+        streamcallback = nothing,
+        max_tokens = max_tokens,
+        model = model,
+        kwargs...)
+end
+
+## Model registration
+## Any alias you like (can be many)
+PromptingTools.MODEL_ALIASES["myprecious"] = "custom-model-xyz"
+## Register the exact model name to send to your API
+PromptingTools.register_model!(;
+    name = "custom-model-xyz",
+    schema = MyCustomSchema())
+
+## Example usage
+api_key = "..." # use ENV to provide this automatically
+url = "..."  # use ENV to provide this or hardcode in your create_chat function!!
+msg = aigenerate("Hello, how are you?"; model = "myprecious", api_kwargs = (; api_key, url))
+
+## Custom usage - no need to register anything
+function myai(msg::AbstractString)
+    model = "custom-model-xyz"
+    schema = MyCustomSchema()
+    api_key = "..." # use ENV to provide this automatically
+    url = "..."  # use ENV to provide this or hardcode in your create_chat function!!
+    aigenerate(schema, msg; model, api_kwargs = (; api_key, url))
+end
+msg = myai("Hello, how are you?")

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -207,6 +207,21 @@ Requires one environment variables to be set:
 """
 struct DeepSeekOpenAISchema <: AbstractOpenAISchema end
 
+"""
+    OpenRouterOpenAISchema
+
+Schema to call the [OpenRouter](https://openrouter.ai/) API.
+
+Links:
+- [Get your API key](https://openrouter.ai/keys)
+- [API Reference](https://openrouter.ai/docs)
+- [Available models](https://openrouter.ai/models)
+
+Requires one environment variable to be set:
+- `OPENROUTER_API_KEY`: Your API key
+"""
+struct OpenRouterOpenAISchema <: AbstractOpenAISchema end
+
 abstract type AbstractOllamaSchema <: AbstractPromptSchema end
 
 """

--- a/src/llm_ollama.jl
+++ b/src/llm_ollama.jl
@@ -12,21 +12,24 @@
     render(schema::AbstractOllamaSchema,
         messages::Vector{<:AbstractMessage};
         conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        no_system_message::Bool = false,
         kwargs...)
 
 Builds a history of the conversation to provide the prompt to the API. All unspecified kwargs are passed as replacements such that `{{key}}=>value` in the template.
 
 # Keyword Arguments
 - `conversation`: An optional vector of `AbstractMessage` objects representing the conversation history. If not provided, it is initialized as an empty vector.
-
+- `no_system_message`: If `true`, do not include the default system message in the conversation history OR convert any provided system message to a user message.
 """
 function render(schema::AbstractOllamaSchema,
         messages::Vector{<:AbstractMessage};
         conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        no_system_message::Bool = false,
         kwargs...)
     ##
     ## First pass: keep the message types but make the replacements provided in `kwargs`
-    messages_replaced = render(NoSchema(), messages; conversation, kwargs...)
+    messages_replaced = render(
+        NoSchema(), messages; conversation, no_system_message, kwargs...)
 
     ## Second pass: convert to the OpenAI schema
     conversation = Dict{String, Any}[]
@@ -140,13 +143,15 @@ function aigenerate(prompt_schema::AbstractOllamaSchema, prompt::ALLOWED_PROMPT_
         model::String = MODEL_CHAT,
         return_all::Bool = false, dry_run::Bool = false,
         conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        no_system_message::Bool = false,
         http_kwargs::NamedTuple = NamedTuple(), api_kwargs::NamedTuple = NamedTuple(),
         kwargs...)
     ##
     global MODEL_ALIASES
     ## Find the unique ID for the model alias provided
     model_id = get(MODEL_ALIASES, model, model)
-    conv_rendered = render(prompt_schema, prompt; conversation, kwargs...)
+    conv_rendered = render(
+        prompt_schema, prompt; conversation, no_system_message, kwargs...)
 
     if !dry_run
         time = @elapsed resp = ollama_api(prompt_schema, nothing;
@@ -176,6 +181,7 @@ function aigenerate(prompt_schema::AbstractOllamaSchema, prompt::ALLOWED_PROMPT_
         conversation,
         return_all,
         dry_run,
+        no_system_message,
         kwargs...)
     return output
 end

--- a/src/llm_shared.jl
+++ b/src/llm_shared.jl
@@ -11,6 +11,7 @@ role4render(schema::AbstractPromptSchema, msg::AIMessage) = "assistant"
     render(schema::NoSchema,
         messages::Vector{<:AbstractMessage};
         conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        no_system_message::Bool = false,
         replacement_kwargs...)
 
 Renders a conversation history from a vector of messages with all replacement variables specified in `replacement_kwargs`.
@@ -20,6 +21,7 @@ It is the first pass of the prompt rendering system, and is used by all other sc
 # Keyword Arguments
 - `image_detail`: Only for `UserMessageWithImages`. It represents the level of detail to include for images. Can be `"auto"`, `"high"`, or `"low"`.
 - `conversation`: An optional vector of `AbstractMessage` objects representing the conversation history. If not provided, it is initialized as an empty vector.
+- `no_system_message`: If `true`, do not include the default system message in the conversation history OR convert any provided system message to a user message.
 
 # Notes
 - All unspecified kwargs are passed as replacements such that `{{key}}=>value` in the template.
@@ -29,6 +31,7 @@ It is the first pass of the prompt rendering system, and is used by all other sc
 function render(schema::NoSchema,
         messages::Vector{<:AbstractMessage};
         conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        no_system_message::Bool = false,
         replacement_kwargs...)
     ## copy the conversation to avoid mutating the original
     conversation = copy(conversation)
@@ -41,8 +44,9 @@ function render(schema::NoSchema,
             replacements = ["{{$(key)}}" => value
                             for (key, value) in pairs(replacement_kwargs)
                             if key in msg.variables]
+            ## Force System message to UserMessage if no_system_message=true
+            MSGTYPE = no_system_message && issystemmessage(msg) ? UserMessage : typeof(msg)
             # Rebuild the message with the replaced content
-            MSGTYPE = typeof(msg)
             new_msg = MSGTYPE(;
                 # unpack the type to replace only the content field
                 [(field, getfield(msg, field)) for field in fieldnames(typeof(msg))]...,
@@ -70,8 +74,10 @@ function render(schema::NoSchema,
     ## Multiple system prompts are not allowed
     (count_system_msg > 1) && throw(ArgumentError("Only one system message is allowed."))
     ## Add default system prompt if not provided
-    (count_system_msg == 0) && pushfirst!(conversation,
-        SystemMessage("Act as a helpful AI assistant"))
+    if (count_system_msg == 0) && !no_system_message
+        pushfirst!(conversation,
+            SystemMessage("Act as a helpful AI assistant"))
+    end
 
     return conversation
 end
@@ -82,6 +88,7 @@ end
         return_all::Bool = false,
         dry_run::Bool = false,
         conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        no_system_message::Bool = false,
         kwargs...)
 
 Finalizes the outputs of the ai* functions by either returning the conversation history or the last message.
@@ -92,19 +99,21 @@ Finalizes the outputs of the ai* functions by either returning the conversation 
   Useful for debugging when you want to check the specific schema rendering. 
 - `conversation::AbstractVector{<:AbstractMessage}=[]`: An optional vector of `AbstractMessage` objects representing the conversation history. If not provided, it is initialized as an empty vector.
 - `kwargs...`: Variables to replace in the prompt template.
+- `no_system_message::Bool=false`: If true, the default system message is not included in the conversation history. Any existing system message is converted to a `UserMessage`.
 """
 function finalize_outputs(prompt::ALLOWED_PROMPT_TYPE, conv_rendered::Any,
         msg::Union{Nothing, AbstractMessage, AbstractVector{<:AbstractMessage}};
         return_all::Bool = false,
         dry_run::Bool = false,
         conversation::AbstractVector{<:AbstractMessage} = AbstractMessage[],
+        no_system_message::Bool = false,
         kwargs...)
     if return_all
         if !dry_run
             # If not a dry_run, re-create the messages sent to the model before schema application
             # This is a duplication of work, as we already have the rendered messages in conv_rendered,
             # but we prioritize the user's experience over performance here (ie, render(OpenAISchema,msgs) does everything under the hood)
-            output = render(NoSchema(), prompt; conversation, kwargs...)
+            output = render(NoSchema(), prompt; conversation, no_system_message, kwargs...)
             if msg isa AbstractVector
                 ## handle multiple messages (multi-sample)
                 append!(output, msg)

--- a/test/llm_shared.jl
+++ b/test/llm_shared.jl
@@ -1,6 +1,6 @@
 using PromptingTools: render, NoSchema
 using PromptingTools: AIMessage, SystemMessage, AbstractMessage, AbstractChatMessage
-using PromptingTools: UserMessage, UserMessageWithImages
+using PromptingTools: UserMessage, UserMessageWithImages, DataMessage
 using PromptingTools: finalize_outputs, role4render
 
 @testset "render-NoSchema" begin
@@ -179,9 +179,34 @@ using PromptingTools: finalize_outputs, role4render
     ]
     conversation = render(schema, messages)
     @test conversation == expected_output
+
+    # Test no_system_message
+    messages = [
+        SystemMessage("System message 1"),
+        UserMessage("User message")
+    ]
+    expected_output = [
+        UserMessage("System message 1"),
+        UserMessage("User message")
+    ]
+    conversation = render(schema, messages; no_system_message = true)
+    @test conversation[1] isa UserMessage
+    @test conversation[2] isa UserMessage
+    @test conversation[1].content == "System message 1"
+    @test conversation[2].content == "User message"
+
+    ## No default message 
+    messages = [
+        UserMessage("User message")
+    ]
+    expected_output = [
+        UserMessage("User message")
+    ]
+    conversation = render(schema, messages; no_system_message = true)
+    @test conversation[1] isa UserMessage
+    @test conversation[1].content == "User message"
 end
 
-# Write 5 unit tests for finalize_outputs for various combinations of inputs. Use @test calls
 @testset "finalize_outputs" begin
     # Given a vector of messages and a single message, it should return the last message.
     messages = [


### PR DESCRIPTION
### Added
- Added support for OpenRouter's API (you must set ENV `OPENROUTER_API_KEY`) to provide access to more models like Cohere Command R+ and OpenAI's o1 series. Reference [OpenRouter](https://openrouter.ai/).
- Added new OpenRouter hosted models to the model registry (prefixed with `or`): `oro1` (OpenAI's o1-preview), `oro1m` (OpenAI's o1-mini), `orcop` (Cohere's command-r-plus), `orco` (Cohere's command-r). The `or` prefix is to avoid conflicts with existing models and OpenAI's aliases, then the goal is to provide 2 letters for each model and 1 letter for additional qualifier (eg, "p" for plus, "m" for mini) -> `orcop` (OpenRouter cohere's COmmand-r-Plus).

### Updated
- Updated FAQ with instructions on how to access new OpenAI o1 models via OpenRouter.
- Updated FAQ with instructions on how to add custom APIs (with an example `examples/adding_custom_API.jl`).
