### PR TITLE
Fix logging for streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.56.1]
+
+### Fixed
+- Removed accidental INFO log in Anthropic's `aigenerate`
+- Changed internal logging in `streamcallback` to use `@debug` when printing raw data chunks.
+
 ## [0.56.0]
 
 ### Updated

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.56.0"
+version = "0.56.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/llm_anthropic.jl
+++ b/src/llm_anthropic.jl
@@ -350,7 +350,6 @@ function aigenerate(
         prompt_schema, prompt; no_system_message, aiprefill, conversation, cache, kwargs...)
 
     if !dry_run
-        @info conv_rendered.conversation
         time = @elapsed resp = anthropic_api(
             prompt_schema, conv_rendered.conversation; api_key,
             conv_rendered.system, endpoint = "messages", model = model_id, streamcallback, http_kwargs, cache,

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -49,7 +49,7 @@ For more complex use cases, you can define your own `callback`. See the interfac
 - `out`: The output stream, eg, `stdout` or a pipe.
 - `flavor`: The stream flavor which might or might not differ between different providers, eg, `OpenAIStream` or `AnthropicStream`.
 - `chunks`: The list of received `StreamChunk` chunks.
-- `verbose`: Whether to print verbose information.
+- `verbose`: Whether to print verbose information. If you enable DEBUG logging, you will see the chunks as they come in.
 - `throw_on_error`: Whether to throw an error if an error message is detected in the streaming response.
 - `kwargs`: Any custom keyword arguments required for your use case.
 
@@ -458,7 +458,8 @@ function streamed_request!(cb::AbstractStreamCallback, url, headers, input; kwar
                 cb.flavor, masterchunk; verbose, spillover, cb.kwargs...)
 
             for chunk in chunks
-                verbose && @info "Chunk Data: $(chunk.data)"
+                ## Note you must have debug logging enabled to see this
+                verbose && @debug "Chunk Data: $(chunk.data)"
                 ## look for errors
                 handle_error_message(chunk; cb.throw_on_error, verbose, cb.kwargs...)
                 ## look for termination signal, but process all remaining chunks first


### PR DESCRIPTION
- Removed accidental INFO log in Anthropic's `aigenerate`
- Changed internal logging in `streamcallback` to use `@debug` when printing raw data chunks.
