### PR TITLE
Add Cerebras API + node validation for airetry!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.58.0]
+
+### Added
+- Added support for [Cerebras](https://cloud.cerebras.ai) hosted models (set your ENV `CEREBRAS_API_KEY`). Available model aliases: `cl3` (Llama3.1 8bn), `cl70` (Llama3.1 70bn).
+- Added a kwarg to `aiclassify` to provide a custom token ID mapping (`token_ids_map`) to work with custom tokenizers.
+
+### Updated
+- Improved the implementation of `airetry!` to concatenate feedback from all ancestor nodes ONLY IF `feedback_inplace=true` (because otherwise LLM can see it in the message history).
+
+### Fixed
+- Fixed a potential bug in `airetry!` where the `aicall` object was not properly validated to ensure it has been `run!` first.
+
 ## [0.57.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.57.0"
+version = "0.58.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/Experimental/AgentTools/retry.jl
+++ b/src/Experimental/AgentTools/retry.jl
@@ -302,7 +302,6 @@ function airetry!(f_cond::Function, aicall::AICallBlock,
         ## Evaluation + feedback (sample is either the "successful" node or the best node to retry from)
         condition_passed, sample = evaluate_condition!(f_cond, aicall, feedback;
             evaluate_all, feedback_expensive)
-        @info "Condition passed: $condition_passed, sample: $(sample.data)"
 
         ## Update the aicall
         aicall.conversation = sample.data
@@ -330,7 +329,6 @@ function airetry!(f_cond::Function, aicall::AICallBlock,
 
         ## Append feedback if provided
         if sample.feedback != ""
-            @info "Adding feedback: $(sample.feedback) with feedback_inplace: $feedback_inplace"
             aicall.conversation = add_feedback!(aicall.conversation, sample;
                 feedback_inplace, feedback_template)
         end
@@ -438,7 +436,6 @@ function evaluate_condition!(f_cond::Function, aicall::AICallBlock,
                         sample.feedback *= "\n" * feedback
                     end
                 end
-                @info "Sample ($(sample.id)) feedback: $(sample.feedback)"
             end
             ## Backprop the results
             backpropagate!(sample; wins = result, visits = 1)
@@ -519,7 +516,6 @@ function add_feedback!(conversation::AbstractVector{<:PT.AbstractMessage},
     else
         sample.feedback
     end
-    @info "All feedback: $(all_feedback)"
     ## short circuit if no feedback
     if strip(all_feedback) == ""
         return conversation
@@ -532,7 +528,6 @@ function add_feedback!(conversation::AbstractVector{<:PT.AbstractMessage},
         output = PT.render(schema, output; feedback = all_feedback) # replace the placeholder
         output[end] # UserMessage with the feedback
     end
-    @info "Feedback message: $(feedback_message.content)"
     if feedback_inplace
         ## Remove AI Message and extract he user message
         user_msg = pop!(conversation) ## pop the last AI message
@@ -541,7 +536,6 @@ function add_feedback!(conversation::AbstractVector{<:PT.AbstractMessage},
                 throw("Something went wrong, no user messages detected to add feedback into.")
             ## keep popping until we find the user message
             user_msg = pop!(conversation)
-            @info "Popped user message: $(user_msg.content)"
         end
         ## Concatenate the feedback message with the user message
         user_msg = PT.UserMessage(;
@@ -551,6 +545,5 @@ function add_feedback!(conversation::AbstractVector{<:PT.AbstractMessage},
         ## append the feedback message to the conversation
         push!(conversation, feedback_message)
     end
-    @info "Conversation: $(conversation[end].content)"
     return conversation
 end

--- a/src/Experimental/AgentTools/retry.jl
+++ b/src/Experimental/AgentTools/retry.jl
@@ -4,9 +4,11 @@
         verbose::Bool = true, throw::Bool = false, evaluate_all::Bool = true, feedback_expensive::Bool = false,
         max_retries::Union{Nothing, Int} = nothing, retry_delay::Union{Nothing, Int} = nothing)
 
-Evaluates the condition `f_cond` on the `aicall` object. 
+Evaluates the condition `f_cond` on the `aicall` object.
 If the condition is not met, it will return the best sample to retry from and provide `feedback` (string or function) to `aicall`. That's why it's mutating.
 It will retry maximum `max_retries` times, with `throw=true`, an error will be thrown if the condition is not met after `max_retries` retries.
+
+Note: `aicall` must be run first via `run!(aicall)` before calling `airetry!`.
 
 Function signatures
 - `f_cond(aicall::AICallBlock) -> Bool`, ie, it must accept the aicall object and return a boolean value.
@@ -286,6 +288,9 @@ function airetry!(f_cond::Function, aicall::AICallBlock,
     (; config) = aicall
     (; max_calls, feedback_inplace, feedback_template) = aicall.config
 
+    ## Validate that the aicall has been run first
+    @assert aicall.success isa Bool "Provided `aicall` has not been run yet. Use `run!(aicall)` first, before calling `airetry!` to check the condition."
+
     max_retries = max_retries isa Nothing ? config.max_retries : max_retries
     retry_delay = retry_delay isa Nothing ? config.retry_delay : retry_delay
     verbose = min(verbose, get(aicall.kwargs, :verbose, 99))
@@ -297,6 +302,7 @@ function airetry!(f_cond::Function, aicall::AICallBlock,
         ## Evaluation + feedback (sample is either the "successful" node or the best node to retry from)
         condition_passed, sample = evaluate_condition!(f_cond, aicall, feedback;
             evaluate_all, feedback_expensive)
+        @info "Condition passed: $condition_passed, sample: $(sample.data)"
 
         ## Update the aicall
         aicall.conversation = sample.data
@@ -324,6 +330,7 @@ function airetry!(f_cond::Function, aicall::AICallBlock,
 
         ## Append feedback if provided
         if sample.feedback != ""
+            @info "Adding feedback: $(sample.feedback) with feedback_inplace: $feedback_inplace"
             aicall.conversation = add_feedback!(aicall.conversation, sample;
                 feedback_inplace, feedback_template)
         end
@@ -431,6 +438,7 @@ function evaluate_condition!(f_cond::Function, aicall::AICallBlock,
                         sample.feedback *= "\n" * feedback
                     end
                 end
+                @info "Sample ($(sample.id)) feedback: $(sample.feedback)"
             end
             ## Backprop the results
             backpropagate!(sample; wins = result, visits = 1)
@@ -505,8 +513,13 @@ conversation[end].content ==
 function add_feedback!(conversation::AbstractVector{<:PT.AbstractMessage},
         sample::SampleNode; feedback_inplace::Bool = false,
         feedback_template::Symbol = :FeedbackFromEvaluator)
-    ##
-    all_feedback = collect_all_feedback(sample)
+    ## If you use in-place feedback, collect all feedback from ancestors (because you won't see the history otherwise)
+    all_feedback = if feedback_inplace
+        collect_all_feedback(sample)
+    else
+        sample.feedback
+    end
+    @info "All feedback: $(all_feedback)"
     ## short circuit if no feedback
     if strip(all_feedback) == ""
         return conversation
@@ -519,6 +532,7 @@ function add_feedback!(conversation::AbstractVector{<:PT.AbstractMessage},
         output = PT.render(schema, output; feedback = all_feedback) # replace the placeholder
         output[end] # UserMessage with the feedback
     end
+    @info "Feedback message: $(feedback_message.content)"
     if feedback_inplace
         ## Remove AI Message and extract he user message
         user_msg = pop!(conversation) ## pop the last AI message
@@ -527,6 +541,7 @@ function add_feedback!(conversation::AbstractVector{<:PT.AbstractMessage},
                 throw("Something went wrong, no user messages detected to add feedback into.")
             ## keep popping until we find the user message
             user_msg = pop!(conversation)
+            @info "Popped user message: $(user_msg.content)"
         end
         ## Concatenate the feedback message with the user message
         user_msg = PT.UserMessage(;
@@ -536,5 +551,6 @@ function add_feedback!(conversation::AbstractVector{<:PT.AbstractMessage},
         ## append the feedback message to the conversation
         push!(conversation, feedback_message)
     end
+    @info "Conversation: $(conversation[end].content)"
     return conversation
 end

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -233,6 +233,20 @@ Requires one environment variable to be set:
 """
 struct OpenRouterOpenAISchema <: AbstractOpenAISchema end
 
+"""
+    CerebrasOpenAISchema
+
+Schema to call the [Cerebras](https://cerebras.ai/) API.
+
+Links:
+- [Get your API key](https://cloud.cerebras.ai)
+- [API Reference](https://inference-docs.cerebras.ai/api-reference/chat-completions)
+
+Requires one environment variable to be set:
+- `CEREBRAS_API_KEY`: Your API key
+"""
+struct CerebrasOpenAISchema <: AbstractOpenAISchema end
+
 abstract type AbstractOllamaSchema <: AbstractPromptSchema end
 
 """

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -24,6 +24,7 @@ Check your preferences by calling `get_preferences(key::String)`.
 - `GROQ_API_KEY`: The API key for the Groq API. Free in beta! Get yours from [here](https://console.groq.com/keys).
 - `DEEPSEEK_API_KEY`: The API key for the DeepSeek API. Get \$5 credit when you join. Get yours from [here](https://platform.deepseek.com/api_keys).
 - `OPENROUTER_API_KEY`: The API key for the OpenRouter API. Get yours from [here](https://openrouter.ai/keys).
+- `CEREBRAS_API_KEY`: The API key for the Cerebras API. Get yours from [here](https://cloud.cerebras.ai/).
 - `MODEL_CHAT`: The default model to use for aigenerate and most ai* calls. See `MODEL_REGISTRY` for a list of available models or define your own.
 - `MODEL_EMBEDDING`: The default model to use for aiembed (embedding documents). See `MODEL_REGISTRY` for a list of available models or define your own.
 - `PROMPT_SCHEMA`: The default prompt schema to use for aigenerate and most ai* calls (if not specified in `MODEL_REGISTRY`). Set as a string, eg, `"OpenAISchema"`.
@@ -55,6 +56,7 @@ Define your `register_model!()` calls in your `startup.jl` file to make them ava
 - `GROQ_API_KEY`: The API key for the Groq API. Free in beta! Get yours from [here](https://console.groq.com/keys).
 - `DEEPSEEK_API_KEY`: The API key for the DeepSeek API. Get \$5 credit when you join. Get yours from [here](https://platform.deepseek.com/api_keys).
 - `OPENROUTER_API_KEY`: The API key for the OpenRouter API. Get yours from [here](https://openrouter.ai/keys).
+- `CEREBRAS_API_KEY`: The API key for the Cerebras API.
 - `LOG_DIR`: The directory to save the logs to, eg, when using `SaverSchema <: AbstractTracerSchema`. Defaults to `joinpath(pwd(), "log")`. Refer to `?SaverSchema` for more information on how it works and examples.
 
 Preferences.jl takes priority over ENV variables, so if you set a preference, it will take precedence over the ENV variable.
@@ -78,6 +80,7 @@ const ALLOWED_PREFERENCES = ["MISTRALAI_API_KEY",
     "GROQ_API_KEY",
     "DEEPSEEK_API_KEY",
     "OPENROUTER_API_KEY",  # Added OPENROUTER_API_KEY
+    "CEREBRAS_API_KEY",
     "MODEL_CHAT",
     "MODEL_EMBEDDING",
     "MODEL_ALIASES",
@@ -159,6 +162,7 @@ global VOYAGE_API_KEY::String = ""
 global GROQ_API_KEY::String = ""
 global DEEPSEEK_API_KEY::String = ""
 global OPENROUTER_API_KEY::String = ""
+global CEREBRAS_API_KEY::String = ""
 global LOCAL_SERVER::String = ""
 global LOG_DIR::String = ""
 
@@ -216,6 +220,9 @@ function load_api_keys!()
     global OPENROUTER_API_KEY  # Added OPENROUTER_API_KEY
     OPENROUTER_API_KEY = @load_preference("OPENROUTER_API_KEY",
         default=get(ENV, "OPENROUTER_API_KEY", ""))
+    global CEREBRAS_API_KEY
+    CEREBRAS_API_KEY = @load_preference("CEREBRAS_API_KEY",
+        default=get(ENV, "CEREBRAS_API_KEY", ""))
     global LOCAL_SERVER
     LOCAL_SERVER = @load_preference("LOCAL_SERVER",
         default=get(ENV, "LOCAL_SERVER", ""))
@@ -410,6 +417,11 @@ aliases = merge(
         "gll" => "llama-3.1-405b-reasoning", #l for large
         "gmixtral" => "mixtral-8x7b-32768",
         "ggemma9" => "gemma2-9b-it",
+        ## Cerebras
+        "cl3" => "llama3.1-8b",
+        "cllama3" => "llama3.1-8b",
+        "cl70" => "llama3.1-70b",
+        "cllama70" => "llama3.1-70b",
         ## DeepSeek
         "dschat" => "deepseek-chat",
         "dscode" => "deepseek-coder",
@@ -885,7 +897,17 @@ registry = Dict{String, ModelSpec}(
         OpenRouterOpenAISchema(),
         2e-6,
         2e-6,
-        "Meta's Llama3.1 405b, hosted by OpenRouter. This is a BASE model!! Max output 32K tokens, 131K context. See details [here](https://openrouter.ai/models/meta-llama/llama-3.1-405b)")
+        "Meta's Llama3.1 405b, hosted by OpenRouter. This is a BASE model!! Max output 32K tokens, 131K context. See details [here](https://openrouter.ai/models/meta-llama/llama-3.1-405b)"),
+    "llama3.1-8b" => ModelSpec("llama3.1-8b",
+        CerebrasOpenAISchema(),
+        1e-7,
+        1e-7,
+        "Meta's Llama3.1 8b, hosted by Cerebras.ai. Max 8K context."),
+    "llama3.1-70b" => ModelSpec("llama3.1-70b",
+        CerebrasOpenAISchema(),
+        6e-7,
+        6e-7,
+        "Meta's Llama3.1 70b, hosted by Cerebras.ai. Max 8K context.")
 )
 
 """

--- a/test/Experimental/AgentTools/retry.jl
+++ b/test/Experimental/AgentTools/retry.jl
@@ -42,10 +42,10 @@ using PromptingTools.Experimental.AgentTools: add_feedback!,
     child = expand!(sample, nothing; feedback = "Extra test")
     conversation = [
         PT.UserMessage("User says hello"), PT.AIMessage(; content = "AI responds")]
-    updated_conversation = add_feedback!(conversation, child)
-    @test length(updated_conversation) == 3
+    updated_conversation = add_feedback!(conversation, child; feedback_inplace = true)
+    @test length(updated_conversation) == 1
     @test updated_conversation[end].content ==
-          "### Feedback from Evaluator\nTest Feedback\n----------\nExtra test\n"
+          "User says hello\n\n### Feedback from Evaluator\nTest Feedback\n----------\nExtra test\n"
 
     # Test for attempting to add feedback inplace with no prior user message
     sample = SampleNode(; data = nothing, feedback = "Orphan Feedback")
@@ -140,7 +140,7 @@ end
     ## Try to run before it's initialized
     aicall = AIGenerate(schema, "Say hi!";
         config = RetryConfig(max_retries = 0, retries = 0, calls = 0))
-    @test_throws AssertionError airetry!(condition_func, aicall)
+    @test_throws AssertionError airetry!(==(0), aicall)
 
     # Check condition passing without retries
     aicall = AIGenerate(schema, "Say hi!";

--- a/test/Experimental/AgentTools/retry.jl
+++ b/test/Experimental/AgentTools/retry.jl
@@ -137,6 +137,11 @@ end
         :usage => Dict(:total_tokens => 3, :prompt_tokens => 2, :completion_tokens => 1))
     schema = PT.TestEchoOpenAISchema(; response, status = 200)
 
+    ## Try to run before it's initialized
+    aicall = AIGenerate(schema, "Say hi!";
+        config = RetryConfig(max_retries = 0, retries = 0, calls = 0))
+    @test_throws AssertionError airetry!(condition_func, aicall)
+
     # Check condition passing without retries
     aicall = AIGenerate(schema, "Say hi!";
         config = RetryConfig(max_retries = 0, retries = 0, calls = 0))


### PR DESCRIPTION
### Added
- Added support for [Cerebras](https://cloud.cerebras.ai) hosted models (set your ENV `CEREBRAS_API_KEY`). Available model aliases: `cl3` (Llama3.1 8bn), `cl70` (Llama3.1 70bn).
- Added a kwarg to `aiclassify` to provide a custom token ID mapping (`token_ids_map`) to work with custom tokenizers.

### Updated
- Improved the implementation of `airetry!` to concatenate feedback from all ancestor nodes ONLY IF `feedback_inplace=true` (because otherwise LLM can see it in the message history).

### Fixed
- Fixed a potential bug in `airetry!` where the `aicall` object was not properly validated to ensure it has been `run!` first.
