### PR TITLE
Add a new models, clean up tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extends support for structured extraction with multiple "tools" definitions (see `?aiextract`).
 - Added new primitives `Tool` (to re-use tool definitions) and a function `aitools` to support mixed structured and non-structured workflows, eg, agentic workflows (see `?aitools`).
 - Added a field `name` to `AbstractChatMessage` and `AIToolRequest` messages to enable role-based workflows.
+- Added a support for partial argument execution with `execute_tool` function (provide your own context to override the arg values).
 
 ### Updated
 - Renamed `function_call_signature` to `tool_call_signature` to better reflect that it's used for tools, but kept a link to the old name for back-compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new primitives `Tool` (to re-use tool definitions) and a function `aitools` to support mixed structured and non-structured workflows, eg, agentic workflows (see `?aitools`).
 - Added a field `name` to `AbstractChatMessage` and `AIToolRequest` messages to enable role-based workflows.
 - Added a support for partial argument execution with `execute_tool` function (provide your own context to override the arg values).
+- Added support for [SambaNova](https://sambanova.ai/) hosted models (set your ENV `SAMBANOVA_API_KEY`). 
+- Added many new models from Mistral, Groq, Sambanova, OpenAI.
 
 ### Updated
 - Renamed `function_call_signature` to `tool_call_signature` to better reflect that it's used for tools, but kept a link to the old name for back-compatibility.

--- a/src/extraction.jl
+++ b/src/extraction.jl
@@ -701,6 +701,23 @@ Dictionary is un-ordered, so we need to sort the arguments first and then pass t
 - `f::Function`: The function to execute.
 - `args::AbstractDict{Symbol, <:Any}`: The arguments to pass to the function.
 - `context::AbstractDict{Symbol, <:Any}`: Optional context to pass to the function, it will prioritized to get the argument values from.
+
+# Example
+```julia
+my_function(x, y) = x + y
+execute_tool(my_function, Dict(:x => 1, :y => 2))
+```
+
+```julia
+get_weather(date, location) = "The weather in \$location on \$date is 70 degrees."
+tool_map = PT.tool_call_signature(get_weather)
+
+msg = aitools("What's the weather in Tokyo on May 3rd, 2023?";
+    tools = collect(values(tool_map)))
+
+PT.execute_tool(tool_map, PT.tool_calls(msg)[1])
+# "The weather in Tokyo on 2023-05-03 is 70 degrees."
+```
 """
 function execute_tool(f::Function, args::AbstractDict{Symbol, <:Any},
         context::AbstractDict{Symbol, <:Any} = Dict{Symbol, Any}())

--- a/src/extraction.jl
+++ b/src/extraction.jl
@@ -718,6 +718,15 @@ function execute_tool(tool::AbstractTool, args::AbstractDict{Symbol, <:Any},
         context::AbstractDict{Symbol, <:Any} = Dict{Symbol, Any}())
     return execute_tool(tool.callable, args, context)
 end
+function execute_tool(tool::AbstractTool, msg::ToolMessage,
+        context::AbstractDict{Symbol, <:Any} = Dict{Symbol, Any}())
+    return execute_tool(tool.callable, msg.args, context)
+end
+function execute_tool(tool_map::AbstractDict{String, <:AbstractTool}, msg::ToolMessage,
+        context::AbstractDict{Symbol, <:Any} = Dict{Symbol, Any}())
+    tool = tool_map[msg.name]
+    return execute_tool(tool, msg, context)
+end
 
 """
     Tool(callable::Union{Function, Type, Method}; kwargs...)

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -248,6 +248,20 @@ Requires one environment variable to be set:
 """
 struct CerebrasOpenAISchema <: AbstractOpenAISchema end
 
+"""
+    SambaNovaOpenAISchema
+
+Schema to call the [SambaNova](https://sambanova.ai/) API.
+
+Links:
+- [Get your API key](https://cloud.sambanova.ai/apis)
+- [API Reference](https://community.sambanova.ai/c/docs)
+
+Requires one environment variable to be set:
+- `SAMBANOVA_API_KEY`: Your API key
+"""
+struct SambaNovaOpenAISchema <: AbstractOpenAISchema end
+
 abstract type AbstractOllamaSchema <: AbstractPromptSchema end
 
 """

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -1477,7 +1477,7 @@ function response_to_message(schema::AbstractOpenAISchema,
         ## Note, JSON mode doesn't have tool_call_id so we mock it
         content_blob = choice[:message][:content]
         [ToolMessage(;
-            content = nothing, req_id = run_id, tool_call_id = string("tool-id-", run_id),
+            content = nothing, req_id = run_id, tool_call_id = string("call_", run_id),
             raw = content_blob isa String ? content_blob : JSON3.write(content_blob),
             args = content_blob isa String ? JSON3.read(content_blob) : content_blob,
             name = tool_name)]
@@ -1493,7 +1493,9 @@ function response_to_message(schema::AbstractOpenAISchema,
     else
         ToolMessage[]
     end
-    content = json_mode != true ? choice[:message][:content] : nothing
+    ## Check if content key was provided (not required for tool calls)
+    content = json_mode != true && haskey(choice[:message], :content) ?
+              choice[:message][:content] : nothing
     ## Remember the tools
     extras = Dict{Symbol, Any}()
     if has_tools

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -829,8 +829,10 @@ function response_to_message(schema::AbstractOpenAISchema,
     # "Safe" parsing of the response - it still fails if JSON is invalid
     tools_array = if json_mode == true
         name, tool = only(tool_map)
+        content_blob = choice[:message][:content]
+        content_obj = content_blob isa String ? JSON3.read(content_blob) : content_blob
         [parse_tool(
-            tool.callable, choice[:message][:content])]
+            tool.callable, content_obj)]
     else
         ## If name does not match, we use the callable from the tool_map 
         ## Can happen only in testing with auto-generated struct
@@ -1472,10 +1474,13 @@ function response_to_message(schema::AbstractOpenAISchema,
                 !isempty(choice[:message][:tool_calls])
     tools_array = if json_mode == true
         tool_name, tool = only(tool_map)
+        ## Note, JSON mode doesn't have tool_call_id so we mock it
+        content_blob = choice[:message][:content]
         [ToolMessage(;
-            content = nothing, req_id = run_id, tool_call_id = choice[:id],
-            raw = JSON3.write(choice[:message][:content]),
-            args = choice[:message][:content], name = tool_name)]
+            content = nothing, req_id = run_id, tool_call_id = string("tool-id-", run_id),
+            raw = content_blob isa String ? content_blob : JSON3.write(content_blob),
+            args = content_blob isa String ? JSON3.read(content_blob) : content_blob,
+            name = tool_name)]
     elseif has_tools
         [ToolMessage(; raw = tool_call[:function][:arguments],
              args = JSON3.read(tool_call[:function][:arguments]),
@@ -1631,7 +1636,7 @@ function aitools(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_TYP
     ##
     global MODEL_ALIASES
     ## Function calling specifics // get the tool map (signatures)
-    ## Set strict mode on for JSON mode
+    ## Set strict mode on for JSON mode as Structured outputs
     strict_ = json_mode == true ? true : strict
     tool_map = tool_call_signature(tools; strict = strict_)
     tools = render(prompt_schema, tool_map; json_mode)
@@ -1653,7 +1658,7 @@ function aitools(prompt_schema::AbstractOpenAISchema, prompt::ALLOWED_PROMPT_TYP
         @assert length(tools)==1 "Only 1 tool definition is allowed in JSON mode."
         (; [k => v for (k, v) in pairs(api_kwargs) if k != :tool_choice]...,
             response_format = (;
-                type = "json_schema", json_schema = only(tools)))
+                type = "json_schema", json_schema = only(tools)[:function]))
     elseif isempty(tools)
         api_kwargs
     else

--- a/src/llm_openai_schema_defs.jl
+++ b/src/llm_openai_schema_defs.jl
@@ -196,6 +196,15 @@ function OpenAI.create_chat(schema::CerebrasOpenAISchema,
     api_key = isempty(CEREBRAS_API_KEY) ? api_key : CEREBRAS_API_KEY
     OpenAI.create_chat(CustomOpenAISchema(), api_key, model, conversation; url, kwargs...)
 end
+function OpenAI.create_chat(schema::SambaNovaOpenAISchema,
+        api_key::AbstractString,
+        model::AbstractString,
+        conversation;
+        url::String = "https://api.sambanova.ai/v1",
+        kwargs...)
+    api_key = isempty(SAMBANOVA_API_KEY) ? api_key : SAMBANOVA_API_KEY
+    OpenAI.create_chat(CustomOpenAISchema(), api_key, model, conversation; url, kwargs...)
+end
 function OpenAI.create_chat(schema::DatabricksOpenAISchema,
         api_key::AbstractString,
         model::AbstractString,

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -207,7 +207,7 @@ Returned by `aitools` functions.
 
 See `ToolMessage` for the fields of the tool call requests.
 
-See also: [`tool_calls`](@ref)
+See also: [`tool_calls`](@ref), [`execute_tool`](@ref), [`parse_tool`](@ref)
 """
 Base.@kwdef struct AIToolRequest{T <: Union{AbstractString, Nothing}} <: AbstractDataMessage
     content::T = nothing
@@ -224,7 +224,7 @@ Base.@kwdef struct AIToolRequest{T <: Union{AbstractString, Nothing}} <: Abstrac
     sample_id::Union{Nothing, Int} = nothing
     _type::Symbol = :aitoolrequest
 end
-"Get the vector of tool call requests from an AIToolRequest."
+"Get the vector of tool call requests from an AIToolRequest/message."
 tool_calls(msg::AIToolRequest) = msg.tool_calls
 tool_calls(msg::AbstractMessage) = ToolMessage[]
 tool_calls(msg::ToolMessage) = [msg]

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -160,6 +160,21 @@ Base.@kwdef struct DataMessage{T <: Any} <: AbstractDataMessage
     _type::Symbol = :datamessage
 end
 
+"""
+    ToolMessage
+
+A message type for tool calls. 
+    
+It represents both the request (fields `args`, `name`) and the response (field `content`).
+
+# Fields
+- `content::Any`: The content of the message.
+- `req_id::Union{Nothing, Int}`: The unique ID of the request.
+- `tool_call_id::String`: The unique ID of the tool call.
+- `raw::AbstractString`: The raw JSON string of the tool call request.
+- `args::Union{Nothing, Dict{Symbol, Any}}`: The arguments of the tool call request.
+- `name::Union{Nothing, String}`: The name of the tool call request.
+"""
 Base.@kwdef mutable struct ToolMessage <: AbstractDataMessage
     content::Any = nothing
     req_id::Union{Nothing, Int} = nothing
@@ -170,6 +185,30 @@ Base.@kwdef mutable struct ToolMessage <: AbstractDataMessage
     _type::Symbol = :toolmessage
 end
 
+"""
+    AIToolRequest
+
+A message type for AI-generated tool requests. 
+Returned by `aitools` functions.
+    
+# Fields
+- `content::Union{AbstractString, Nothing}`: The content of the message.
+- `tool_calls::Vector{ToolMessage}`: The vector of tool call requests.
+- `name::Union{Nothing, String}`: The name of the `role` in the conversation.
+- `status::Union{Int, Nothing}`: The status of the message from the API.
+- `tokens::Tuple{Int, Int}`: The number of tokens used (prompt,completion).
+- `elapsed::Float64`: The time taken to generate the response in seconds.
+- `cost::Union{Nothing, Float64}`: The cost of the API call (calculated with information from `MODEL_REGISTRY`).
+- `log_prob::Union{Nothing, Float64}`: The log probability of the response.
+- `extras::Union{Nothing, Dict{Symbol, Any}}`: A dictionary for additional metadata that is not part of the key message fields. Try to limit to a small number of items and singletons to be serializable.
+- `finish_reason::Union{Nothing, String}`: The reason the response was finished.
+- `run_id::Union{Nothing, Int}`: The unique ID of the run.
+- `sample_id::Union{Nothing, Int}`: The unique ID of the sample (if multiple samples are generated, they will all have the same `run_id`).
+
+See `ToolMessage` for the fields of the tool call requests.
+
+See also: [`tool_calls`](@ref)
+"""
 Base.@kwdef struct AIToolRequest{T <: Union{AbstractString, Nothing}} <: AbstractDataMessage
     content::T = nothing
     tool_calls::Vector{ToolMessage} = ToolMessage[]
@@ -185,6 +224,11 @@ Base.@kwdef struct AIToolRequest{T <: Union{AbstractString, Nothing}} <: Abstrac
     sample_id::Union{Nothing, Int} = nothing
     _type::Symbol = :aitoolrequest
 end
+"Get the vector of tool call requests from an AIToolRequest."
+tool_calls(msg::AIToolRequest) = msg.tool_calls
+tool_calls(msg::AbstractMessage) = ToolMessage[]
+tool_calls(msg::ToolMessage) = [msg]
+tool_calls(msg::AbstractTracerMessage) = tool_calls(msg.object)
 
 ### Other Message methods
 # content-only constructor

--- a/test/extraction.jl
+++ b/test/extraction.jl
@@ -765,7 +765,7 @@ end
 end
 
 function context_test_function(x::Int, y::String, ctx_z::Float64)
-    return "Context test: $x, $y, $z"
+    return "Context test: $x, $y, $(ctx_z)"
 end
 @testset "execute_tool" begin
     # Test executing a function with ordered arguments

--- a/test/extraction.jl
+++ b/test/extraction.jl
@@ -3,7 +3,7 @@ using PromptingTools: has_null_type, is_required_field, remove_null_types, to_js
 using PromptingTools: tool_call_signature, set_properties_strict!,
                       update_field_descriptions!, generate_struct
 using PromptingTools: Tool, isabstracttool, execute_tool, parse_tool, get_arg_names,
-                      get_arg_types, get_method, get_function
+                      get_arg_types, get_method, get_function, remove_field!
 
 # TODO: check more edge cases like empty structs
 
@@ -478,6 +478,51 @@ end
     @test !haskey(updated_schema["properties"]["field2"], "description")
 end
 
+@testset "remove_field!" begin
+    # Test removing a field by string
+    parameters = Dict(
+        "properties" => Dict(
+            "field1" => Dict("type" => "string"),
+            "field2" => Dict("type" => "integer")
+        ),
+        "required" => ["field1", "field2"]
+    )
+    remove_field!(parameters, "field1")
+    @test !haskey(parameters["properties"], "field1")
+    @test parameters["required"] == ["field2"]
+
+    # Test removing a non-existent field
+    remove_field!(parameters, "field3")
+    @test parameters["properties"] == Dict("field2" => Dict("type" => "integer"))
+    @test parameters["required"] == ["field2"]
+
+    # Test removing a field by regex
+    parameters = Dict(
+        "properties" => Dict(
+            "user_id" => Dict("type" => "string"),
+            "user_name" => Dict("type" => "string"),
+            "age" => Dict("type" => "integer")
+        ),
+        "required" => ["user_id", "user_name", "age"]
+    )
+    remove_field!(parameters, r"^user_")
+    @test !haskey(parameters["properties"], "user_id")
+    @test !haskey(parameters["properties"], "user_name")
+    @test haskey(parameters["properties"], "age")
+    @test parameters["required"] == ["age"]
+
+    # Test removing with regex that doesn't match any fields
+    remove_field!(parameters, r"^non_existent_")
+    @test parameters["properties"] == Dict("age" => Dict("type" => "integer"))
+    @test parameters["required"] == ["age"]
+
+    # Test with empty properties and required fields
+    parameters = Dict("properties" => Dict(), "required" => String[])
+    remove_field!(parameters, "field")
+    remove_field!(parameters, r"field")
+    @test parameters == Dict("properties" => Dict(), "required" => String[])
+end
+
 @testset "tool_call_signature" begin
     "Some docstring"
     struct MyMeasurement2
@@ -719,6 +764,9 @@ end
     @test result.y == "test"
 end
 
+function context_test_function(x::Int, y::String, ctx_z::Float64)
+    return "Context test: $x, $y, $z"
+end
 @testset "execute_tool" begin
     # Test executing a function with ordered arguments
     args = Dict(:x => 5, :y => "hello")
@@ -730,4 +778,26 @@ end
 
     tool = Tool(my_test_function)
     @test execute_tool(tool, args) == "Test function: 5, hello"
+
+    # Test executing a function with context
+    args = Dict(:x => 5, :y => "hello")
+    context = Dict(:ctx_z => 3.14)
+    @test execute_tool(context_test_function, args, context) ==
+          "Context test: 5, hello, 3.14"
+
+    # Test context overriding args
+    args_override = Dict(:x => 5, :y => "hello", :ctx_z => 2.71)
+    context_override = Dict(:y => "world", :ctx_z => 3.14)
+    @test execute_tool(context_test_function, args_override, context_override) ==
+          "Context test: 5, world, 3.14"
+
+    # Test with missing argument in both args and context
+    args_missing = Dict(:x => 5)
+    context_missing = Dict(:y => "hello")
+    @test_throws MethodError execute_tool(
+        context_test_function, args_missing, context_missing)
+
+    # Test with Tool
+    context_tool = Tool(context_test_function)
+    @test execute_tool(context_tool, args, context) == "Context test: 5, hello, 3.14"
 end

--- a/test/llm_openai.jl
+++ b/test/llm_openai.jl
@@ -1134,7 +1134,7 @@ end
         json_mode = true,
         api_kwargs = (; temperature = 0))
 
-    @test msg_json.tool_calls[1].tool_call_id == "123"
+    @test msg_json.tool_calls[1].tool_call_id == "call_$(msg_json.run_id)"
     @test msg_json.tool_calls[1].name == "get_weather"
     @test msg_json.tool_calls[1].args[:location] == "Tokyo"
     @test msg_json.tool_calls[1].args[:date] == "2023-05-03"


### PR DESCRIPTION
- Added a support for partial argument execution with `execute_tool` function (provide your own context to override the arg values).
- Added support for [SambaNova](https://sambanova.ai/) hosted models (set your ENV `SAMBANOVA_API_KEY`). 
- Added many new models from Mistral, Groq, Sambanova, OpenAI.