### PR TITLE
Anthropic computer use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for Ollama streaming with schema `OllamaSchema` (see `?StreamCallback` for more information). Schema `OllamaManaged` is NOT supported (it's legacy and will be removed in the future).
 - Moved the implementation of streaming callbacks to a new `StreamCallbacks` package.
 - Added new error types for tool execution to enable better error handling and reporting (see `?AbstractToolError`).
+- Added support for Anthropic's new pre-trained tools via `ToolRef` (see `?ToolRef`), to enable the feature, use the `:computer_use` beta header (eg, `aitools(..., betas = [:computer_use])`).
 
 ### Fixed
 - Fixed a bug in `call_cost` where the cost was not calculated if any non-AIMessages were provided in the conversation.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.60.0-DEV"
+version = "0.60.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/PromptingTools.jl
+++ b/src/PromptingTools.jl
@@ -49,7 +49,8 @@ const RESERVED_KWARGS = [
     :no_system_message,
     :aiprefill,
     :name_user,
-    :name_assistant
+    :name_assistant,
+    :betas
 ]
 
 # export replace_words, recursive_splitter, split_by_length, call_cost, auth_header # for debugging only

--- a/src/extraction.jl
+++ b/src/extraction.jl
@@ -49,9 +49,23 @@ end
 Base.show(io::IO, t::AbstractTool) = dump(io, t; maxdepth = 1)
 
 """
-    ToolRef(ref::Symbol)
+    ToolRef(ref::Symbol, callable::Any)
 
-Represents a reference to a tool with a symbolic name. It can be rendered with a `render` method and a prompt schema.
+Represents a reference to a tool with a symbolic name and a callable object (to call during tool execution).
+It can be rendered with a `render` method and a prompt schema.
+
+# Arguments
+- `ref::Symbol`: The symbolic name of the tool.
+- `callable::Any`: The callable object of the tool, eg, a type or a function.
+
+# Examples
+```julia
+# Define a tool with a symbolic name and a callable object
+tool = ToolRef(:computer, println)
+
+# Show the rendered tool signature
+PT.render(PT.AnthropicSchema(), tool)
+```
 """
 Base.@kwdef struct ToolRef <: AbstractTool
     ref::Symbol

--- a/src/extraction.jl
+++ b/src/extraction.jl
@@ -48,6 +48,17 @@ Base.@kwdef struct Tool <: AbstractTool
 end
 Base.show(io::IO, t::AbstractTool) = dump(io, t; maxdepth = 1)
 
+"""
+    ToolRef(ref::Symbol)
+
+Represents a reference to a tool with a symbolic name. It can be rendered with a `render` method and a prompt schema.
+"""
+Base.@kwdef struct ToolRef <: AbstractTool
+    ref::Symbol
+    callable::Any = identity
+end
+Base.show(io::IO, t::ToolRef) = print(io, "ToolRef($(t.ref))")
+
 ### Useful Error Types
 """
     AbstractToolError
@@ -555,6 +566,10 @@ function tool_call_signature(
         end
     end
     return Dict(tool.name => tool)
+end
+function tool_call_signature(
+        tool::ToolRef; kwargs...)
+    Dict(string(tool.ref) => tool)
 end
 
 ## Add support for function signatures

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -98,23 +98,31 @@ function render(schema::AbstractOpenAISchema,
         tools::Vector{<:AbstractTool};
         json_mode::Union{Nothing, Bool} = nothing,
         kwargs...)
-    output = Dict{Symbol, Any}[]
-    for tool in tools
-        rendered = Dict(:type => "function",
-            :function => Dict(
-                :parameters => tool.parameters, :name => tool.name))
-        ## Add strict flag
-        tool.strict == true && (rendered[:function][:strict] = tool.strict)
-        if json_mode == true
-            rendered[:function][:schema] = pop!(rendered[:function], :parameters)
-        else
-            ## Add description if not in JSON mode
-            !isnothing(tool.description) &&
-                (rendered[:function][:description] = tool.description)
-        end
-        push!(output, rendered)
+    [render(schema, tool; json_mode, kwargs...) for tool in tools]
+end
+function render(schema::AbstractOpenAISchema,
+        tool::AbstractTool;
+        json_mode::Union{Nothing, Bool} = nothing,
+        kwargs...)
+    rendered = Dict(:type => "function",
+        :function => Dict(
+            :parameters => tool.parameters, :name => tool.name))
+    ## Add strict flag
+    tool.strict == true && (rendered[:function][:strict] = tool.strict)
+    if json_mode == true
+        rendered[:function][:schema] = pop!(rendered[:function], :parameters)
+    else
+        ## Add description if not in JSON mode
+        !isnothing(tool.description) &&
+            (rendered[:function][:description] = tool.description)
     end
-    return output
+    return rendered
+end
+function render(schema::AbstractOpenAISchema,
+        tool::ToolRef;
+        json_mode::Union{Nothing, Bool} = nothing,
+        kwargs...)
+    throw(ArgumentError("Function `render` is not implemented for the provided schema ($(typeof(schema))) and $(typeof(tool))."))
 end
 
 """

--- a/src/llm_shared.jl
+++ b/src/llm_shared.jl
@@ -99,6 +99,12 @@ function render(schema::AbstractPromptSchema,
         kwargs...)
     render(schema, collect(values(tools)); kwargs...)
 end
+# For ToolRef
+function render(schema::AbstractPromptSchema,
+        tool::AbstractTool;
+        kwargs...)
+    throw(ArgumentError("Function `render` is not implemented for the provided schema ($(typeof(schema))) and $(typeof(tool))."))
+end
 
 """
     finalize_outputs(prompt::ALLOWED_PROMPT_TYPE, conv_rendered::Any,

--- a/test/extraction.jl
+++ b/test/extraction.jl
@@ -4,7 +4,7 @@ using PromptingTools: tool_call_signature, set_properties_strict!,
                       update_field_descriptions!, generate_struct
 using PromptingTools: Tool, isabstracttool, execute_tool, parse_tool, get_arg_names,
                       get_arg_types, get_method, get_function, remove_field!,
-                      tool_call_signature
+                      tool_call_signature, ToolRef
 using PromptingTools: AbstractToolError, ToolNotFoundError, ToolExecutionError,
                       ToolGenericError
 
@@ -77,6 +77,17 @@ end
     @test isabstracttool(tool) == true
     @test isabstracttool(tool_struct) == true
     @test isabstracttool(my_test_function) == false
+
+    ## ToolRef
+    tool = ToolRef(:computer, println)
+    @test tool isa ToolRef
+    @test tool.ref == :computer
+    @test tool.callable == println
+    io = IOBuffer()
+    show(io, tool)
+    output = String(take!(io))
+    @test occursin("ToolRef", output)
+    @test occursin("computer", output)
 end
 
 @testset "has_null_type" begin
@@ -744,6 +755,11 @@ end
     @test tool2.parameters["properties"]["age"]["type"] == "integer"
     @test tool2.parameters["properties"]["height"]["type"] == "integer"
     @test tool2.parameters["properties"]["weight"]["type"] == "number"
+
+    ## ToolRef
+    tool = ToolRef(:computer, println)
+    tool_map = tool_call_signature(tool)
+    @test tool_map == Dict("computer" => tool)
 end
 
 @testset "parse_tool" begin

--- a/test/llm_openai.jl
+++ b/test/llm_openai.jl
@@ -1,7 +1,7 @@
 using PromptingTools: TestEchoOpenAISchema, render, OpenAISchema, role4render
 using PromptingTools: AIMessage, SystemMessage, AbstractMessage
 using PromptingTools: UserMessage, UserMessageWithImages, DataMessage, AIToolRequest,
-                      ToolMessage, Tool
+                      ToolMessage, Tool, ToolRef
 using PromptingTools: CustomProvider,
                       CustomOpenAISchema, MistralOpenAISchema, MODEL_EMBEDDING,
                       MODEL_IMAGE_GENERATION
@@ -200,7 +200,7 @@ using PromptingTools: pick_tokenizer, OPENAI_TOKEN_IDS_GPT35_GPT4, OPENAI_TOKEN_
     messages = [
         SystemMessage("System message"),
         UserMessage("User message"),
-        AIToolRequest(;content="content")
+        AIToolRequest(; content = "content")
     ]
     conversation = render(schema, messages)
     expected_output = Dict{String, Any}[
@@ -323,6 +323,20 @@ end
 
     rendered = render(schema, [strict_tool])
     @test rendered[1][:function][:strict] == true
+
+    ## ToolRef rendering
+    schema = OpenAISchema()
+
+    # Test that rendering ToolRef throws ArgumentError
+    tool = ToolRef(ref = :computer)
+    @test_throws ArgumentError render(schema, tool)
+
+    # Test with json_mode=true
+    @test_throws ArgumentError render(schema, tool; json_mode = true)
+
+    # Test with multiple tools
+    tools = [ToolRef(ref = :computer), ToolRef(ref = :str_replace_editor)]
+    @test_throws ArgumentError render(schema, tools)
 end
 
 @testset "OpenAI.build_url,OpenAI.auth_header" begin

--- a/test/llm_shared.jl
+++ b/test/llm_shared.jl
@@ -1,7 +1,7 @@
 using PromptingTools: render, NoSchema, AbstractPromptSchema
 using PromptingTools: AIMessage, SystemMessage, AbstractMessage, AbstractChatMessage
 using PromptingTools: UserMessage, UserMessageWithImages, DataMessage, AIToolRequest,
-                      ToolMessage
+                      ToolMessage, ToolRef
 using PromptingTools: finalize_outputs, role4render
 
 @testset "render-NoSchema" begin
@@ -214,11 +214,16 @@ using PromptingTools: finalize_outputs, role4render
         [Tool(; name = "f", description = "f", callable = () -> nothing)])
 
     ## different ways to enter tools for rendering
-    opt1=render(OpenAISchema(),
-    [Tool(; name = "f", description = "f", callable = () -> nothing)])
-    opt2=render(OpenAISchema(),
-    Dict("f" => Tool(; name = "f", description = "f", callable = () -> nothing)))
+    opt1 = render(OpenAISchema(),
+        [Tool(; name = "f", description = "f", callable = () -> nothing)])
+    opt2 = render(OpenAISchema(),
+        Dict("f" => Tool(; name = "f", description = "f", callable = () -> nothing)))
     @test opt1 == opt2
+
+    ## ToolRef
+    schema = NoSchema()
+    tool = ToolRef(:computer, println)
+    @test_throws ArgumentError render(schema, tool)
 end
 
 @testset "finalize_outputs" begin


### PR DESCRIPTION
- Added support for Anthropic's new pre-trained tools via `ToolRef` (see `?ToolRef`), to enable the feature, use the `:computer_use` beta header (eg, `aitools(..., betas = [:computer_use])`).