### PR TITLE
Update Callbacks compat + ToolRef definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+## [0.61.0]
+
+### Added
+- Added a new `extras` field to `ToolRef` to enable additional parameters in the tool signature (eg, `display_width_px`, `display_height_px` for the `:computer` tool).
+
 ### Updated
 - Updated the compat bounds for `StreamCallbacks` to enable both v0.4 and v0.5 (Fixes Julia 1.9 compatibility).
-
-### Fixed
+- Updated the return type of `tool_call_signature` to `Dict{String, AbstractTool}` to enable better interoperability with different tool types.
 
 ## [0.60.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Updated
+- Updated the compat bounds for `StreamCallbacks` to enable both v0.4 and v0.5 (Fixes Julia 1.9 compatibility).
+
 ### Fixed
 
 ## [0.60.0]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.60.0"
+version = "0.61.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -55,9 +55,9 @@ REPL = "<0.0.1, 1"
 Random = "<0.0.1, 1"
 SparseArrays = "<0.0.1, 1"
 Statistics = "<0.0.1, 1"
-StreamCallbacks = "0.4"
+StreamCallbacks = "0.4, 0.5"
 Test = "<0.0.1, 1"
-julia = "1.9,1.10"
+julia = "1.9, 1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/llm_anthropic.jl
+++ b/src/llm_anthropic.jl
@@ -839,6 +839,23 @@ conv = aitools(
 # UserMessage("And in New York?")
 # AIToolRequest("-"; Tool Requests: 1)
 ```
+
+Using the the new Computer Use beta feature:
+```julia
+# Define tools (and associated functions to call)
+tool_map = Dict("bash" => PT.ToolRef(; ref=:bash, callable=bash_tool),
+    "computer" => PT.ToolRef(; ref=:computer, callable=computer_tool,
+        extras=Dict("display_width_px" => 1920, "display_height_px" => 1080)),
+    "str_replace_editor" => PT.ToolRef(; ref=:str_replace_editor, callable=edit_tool))
+
+msg = aitools(prompt; tools=collect(values(tool_map)), model="claude", betas=[:computer_use])
+
+PT.pprint(msg)
+# --------------------
+# AI Tool Request
+# --------------------
+# Tool Request: computer, args: Dict{Symbol, Any}(:action => "screenshot")
+```
 """
 function aitools(prompt_schema::AbstractAnthropicSchema, prompt::ALLOWED_PROMPT_TYPE;
         tools::Union{Type, Function, Method, AbstractTool, Vector} = Tool[],

--- a/src/llm_anthropic.jl
+++ b/src/llm_anthropic.jl
@@ -130,13 +130,13 @@ function render(schema::AbstractAnthropicSchema,
         tool::ToolRef;
         kwargs...)
     ## WARNING: We ignore the tool name here, because the names are strict
+    (; extras) = tool
     rendered = if tool.ref == :computer
         Dict(
             "type" => "computer_20241022",
             "name" => "computer",
-            "display_width_px" => 1024,
-            "display_height_px" => 768,
-            "display_number" => 1
+            "display_width_px" => get(extras, "display_width_px", 1024),
+            "display_height_px" => get(extras, "display_height_px", 768)
         )
     elseif tool.ref == :str_replace_editor
         Dict(
@@ -150,6 +150,9 @@ function render(schema::AbstractAnthropicSchema,
         )
     else
         throw(ArgumentError("Unknown tool reference: $(tool.ref)"))
+    end
+    if !isempty(extras)
+        merge!(rendered, extras)
     end
     return rendered
 end

--- a/test/extraction.jl
+++ b/test/extraction.jl
@@ -79,7 +79,7 @@ end
     @test isabstracttool(my_test_function) == false
 
     ## ToolRef
-    tool = ToolRef(:computer, println)
+    tool = ToolRef(; ref = :computer, callable = println)
     @test tool isa ToolRef
     @test tool.ref == :computer
     @test tool.callable == println
@@ -757,7 +757,7 @@ end
     @test tool2.parameters["properties"]["weight"]["type"] == "number"
 
     ## ToolRef
-    tool = ToolRef(:computer, println)
+    tool = ToolRef(; ref = :computer, callable = println)
     tool_map = tool_call_signature(tool)
     @test tool_map == Dict("computer" => tool)
 end

--- a/test/llm_anthropic.jl
+++ b/test/llm_anthropic.jl
@@ -282,6 +282,16 @@ end
     @test rendered["name"] == "computer"
     @test rendered["display_width_px"] == 1024
     @test rendered["display_height_px"] == 768
+    @test !haskey(rendered, "display_number")
+
+    computer_tool2 = ToolRef(ref = :computer,
+        extras = Dict("display_width_px" => 1920,
+            "display_height_px" => 1080, "display_number" => 1))
+    rendered = render(schema, computer_tool2)
+    @test rendered["type"] == "computer_20241022"
+    @test rendered["name"] == "computer"
+    @test rendered["display_width_px"] == 1920
+    @test rendered["display_height_px"] == 1080
     @test rendered["display_number"] == 1
 
     # Test text editor tool rendering

--- a/test/llm_shared.jl
+++ b/test/llm_shared.jl
@@ -1,4 +1,4 @@
-using PromptingTools: render, NoSchema, AbstractPromptSchema
+using PromptingTools: render, NoSchema, AbstractPromptSchema, OpenAISchema
 using PromptingTools: AIMessage, SystemMessage, AbstractMessage, AbstractChatMessage
 using PromptingTools: UserMessage, UserMessageWithImages, DataMessage, AIToolRequest,
                       ToolMessage, ToolRef
@@ -222,7 +222,7 @@ using PromptingTools: finalize_outputs, role4render
 
     ## ToolRef
     schema = NoSchema()
-    tool = ToolRef(:computer, println)
+    tool = ToolRef(; ref = :computer)
     @test_throws ArgumentError render(schema, tool)
 end
 


### PR DESCRIPTION
### Added
- Added a new `extras` field to `ToolRef` to enable additional parameters in the tool signature (eg, `display_width_px`, `display_height_px` for the `:computer` tool).

### Updated
- Updated the compat bounds for `StreamCallbacks` to enable both v0.4 and v0.5 (Fixes Julia 1.9 compatibility).
- Updated the return type of `tool_call_signature` to `Dict{String, AbstractTool}` to enable better interoperability with different tool types.