### PR TITLE
Add support for Haiku 3.5 and Grok2 Beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.62.0]
+
+### Added
+- Added a new Claude 3.5 Haiku model (`claude-3-5-haiku-latest`) and updated the alias `claudeh` with it.
+- Added support for XAI's Grok 2 beta model (`grok-beta`) and updated the alias `grok` with it. Set your ENV api key `XAI_API_KEY` to use it.
+
 ## [0.61.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.61.0"
+version = "0.62.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/llm_interface.jl
+++ b/src/llm_interface.jl
@@ -262,6 +262,18 @@ Requires one environment variable to be set:
 """
 struct SambaNovaOpenAISchema <: AbstractOpenAISchema end
 
+"""
+    XAIOpenAISchema
+
+Schema to call the XAI API. It follows OpenAI API conventions.
+
+Get your API key from [here](https://console.x.ai/).
+
+Requires one environment variable to be set:
+- `XAI_API_KEY`: Your API key
+"""
+struct XAIOpenAISchema <: AbstractOpenAISchema end
+
 abstract type AbstractOllamaSchema <: AbstractPromptSchema end
 
 """

--- a/src/llm_openai_schema_defs.jl
+++ b/src/llm_openai_schema_defs.jl
@@ -205,6 +205,15 @@ function OpenAI.create_chat(schema::SambaNovaOpenAISchema,
     api_key = isempty(SAMBANOVA_API_KEY) ? api_key : SAMBANOVA_API_KEY
     OpenAI.create_chat(CustomOpenAISchema(), api_key, model, conversation; url, kwargs...)
 end
+function OpenAI.create_chat(schema::XAIOpenAISchema,
+        api_key::AbstractString,
+        model::AbstractString,
+        conversation;
+        url::String = "https://api.x.ai/v1",
+        kwargs...)
+    api_key = isempty(XAI_API_KEY) ? api_key : XAI_API_KEY
+    OpenAI.create_chat(CustomOpenAISchema(), api_key, model, conversation; url, kwargs...)
+end
 function OpenAI.create_chat(schema::DatabricksOpenAISchema,
         api_key::AbstractString,
         model::AbstractString,
@@ -361,6 +370,17 @@ function OpenAI.create_embeddings(schema::FireworksOpenAISchema,
         kwargs...)
     provider = CustomProvider(;
         api_key = isempty(FIREWORKS_API_KEY) ? api_key : FIREWORKS_API_KEY,
+        base_url = url)
+    OpenAI.create_embeddings(provider, docs, model; kwargs...)
+end
+function OpenAI.create_embeddings(schema::XAIOpenAISchema,
+        api_key::AbstractString,
+        docs,
+        model::AbstractString;
+        url::String = "https://api.x.ai/v1",
+        kwargs...)
+    provider = CustomProvider(;
+        api_key = isempty(XAI_API_KEY) ? api_key : XAI_API_KEY,
         base_url = url)
     OpenAI.create_embeddings(provider, docs, model; kwargs...)
 end


### PR DESCRIPTION
- Added a new Claude 3.5 Haiku model (`claude-3-5-haiku-latest`) and updated the alias `claudeh` with it.
- Added support for XAI's Grok 2 beta model (`grok-beta`) and updated the alias `grok` with it. Set your ENV api key `XAI_API_KEY` to use it.
