### PR TITLE
[Breaking] Renamed MISTRALAI to MISTRAL everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -601,6 +601,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0]
 
+### Breaking
+- Changed the official ENV variable for MistralAI API from `MISTRALAI_API_KEY` to `MISTRAL_API_KEY` to be compatible with the Mistral docs.
+
 ### Added
 - Improved AICode parsing and error handling (eg, capture more REPL prompts, detect parsing errors earlier, parse more code fence types), including the option to remove unsafe code (eg, `Pkg.add("SomePkg")`) with `AICode(msg; skip_unsafe=true, vebose=true)`
 - Added new prompt templates: `JuliaRecapTask`, `JuliaRecapCoTTask`, `JuliaExpertTestCode` and updated `JuliaExpertCoTTask` to be more robust against early stopping for smaller OSS models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,7 +604,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Improved AICode parsing and error handling (eg, capture more REPL prompts, detect parsing errors earlier, parse more code fence types), including the option to remove unsafe code (eg, `Pkg.add("SomePkg")`) with `AICode(msg; skip_unsafe=true, vebose=true)`
 - Added new prompt templates: `JuliaRecapTask`, `JuliaRecapCoTTask`, `JuliaExpertTestCode` and updated `JuliaExpertCoTTask` to be more robust against early stopping for smaller OSS models
-- Added support for MistralAI API via the MistralOpenAISchema(). All their standard models have been registered, so you should be able to just use `model="mistral-tiny` in your `aigenerate` calls without any further changes. Remember to either provide `api_kwargs.api_key` or ensure you have ENV variable `MISTRALAI_API_KEY` set.
+- Added support for MistralAI API via the MistralOpenAISchema(). All their standard models have been registered, so you should be able to just use `model="mistral-tiny` in your `aigenerate` calls without any further changes. Remember to either provide `api_kwargs.api_key` or ensure you have ENV variable `MISTRAL_API_KEY` set.
 - Added support for any OpenAI-compatible API via `schema=CustomOpenAISchema()`. All you have to do is to provide your `api_key` and `url` (base URL of the API) in the `api_kwargs` keyword argument. This option is useful if you use [Perplexity.ai](https://docs.perplexity.ai/), [Fireworks.ai](https://app.fireworks.ai/), or any other similar services.
 
 ## [0.3.0]

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ Under the hood, we use a dedicated schema `MistralOpenAISchema` that leverages m
 
 ```julia
 const PT = PromptingTools
-msg = aigenerate(PT.MistralOpenAISchema(), "Say Hi!"; model="mistral-tiny", api_key=ENV["MISTRALAI_API_KEY"])
+msg = aigenerate(PT.MistralOpenAISchema(), "Say Hi!"; model="mistral-tiny", api_key=ENV["MISTRAL_API_KEY"])
 ```
 As you can see, we can load your API key either from the ENV or via the Preferences.jl mechanism (see `?PREFERENCES` for more information).
 
@@ -750,7 +750,7 @@ Resources:
 
 ### Configuring the Environment Variable for API Key
 
-This is a guide for OpenAI's API key, but it works for any other API key you might need (eg, `MISTRALAI_API_KEY` for MistralAI API).
+This is a guide for OpenAI's API key, but it works for any other API key you might need (eg, `MISTRAL_API_KEY` for MistralAI API).
 
 To use the OpenAI API with PromptingTools.jl, set your API key as an environment variable:
 

--- a/docs/src/examples/readme_examples.md
+++ b/docs/src/examples/readme_examples.md
@@ -437,7 +437,7 @@ Under the hood, we use a dedicated schema `MistralOpenAISchema` that leverages m
 
 ```julia
 const PT = PromptingTools
-msg = aigenerate(PT.MistralOpenAISchema(), "Say Hi!"; model="mistral-tiny", api_key=ENV["MISTRALAI_API_KEY"])
+msg = aigenerate(PT.MistralOpenAISchema(), "Say Hi!"; model="mistral-tiny", api_key=ENV["MISTRAL_API_KEY"])
 ```
 As you can see, we can load your API key either from the ENV or via the Preferences.jl mechanism (see `?PREFERENCES` for more information).
 

--- a/docs/src/examples/working_with_custom_apis.md
+++ b/docs/src/examples/working_with_custom_apis.md
@@ -23,7 +23,7 @@ Under the hood, we use a dedicated schema `MistralOpenAISchema` that leverages m
 
 ```julia
 const PT = PromptingTools
-msg = aigenerate(PT.MistralOpenAISchema(), "Say Hi!"; model="mistral-tiny", api_key=ENV["MISTRALAI_API_KEY"])
+msg = aigenerate(PT.MistralOpenAISchema(), "Say Hi!"; model="mistral-tiny", api_key=ENV["MISTRAL_API_KEY"])
 ```
 As you can see, we can load your API key either from the ENV or via the Preferences.jl mechanism (see `?PREFERENCES` for more information).
 

--- a/docs/src/frequently_asked_questions.md
+++ b/docs/src/frequently_asked_questions.md
@@ -148,7 +148,7 @@ msg = aigenerate("What is the meaning of life?"; model="oro1m", no_system_messag
 
 ## Configuring the Environment Variable for API Key
 
-This is a guide for OpenAI's API key, but it works for any other API key you might need (eg, `MISTRALAI_API_KEY` for MistralAI API).
+This is a guide for OpenAI's API key, but it works for any other API key you might need (eg, `MISTRAL_API_KEY` for MistralAI API).
 
 To use the OpenAI API with PromptingTools.jl, set your API key as an environment variable:
 

--- a/src/llm_openai_schema_defs.jl
+++ b/src/llm_openai_schema_defs.jl
@@ -129,7 +129,7 @@ end
 
 Dispatch to the OpenAI.create_chat function, but with the MistralAI API parameters. 
 
-It tries to access the `MISTRALAI_API_KEY` ENV variable, but you can also provide it via the `api_key` keyword argument.
+It tries to access the `MISTRAL_API_KEY` ENV variable, but you can also provide it via the `api_key` keyword argument.
 """
 function OpenAI.create_chat(schema::MistralOpenAISchema,
         api_key::AbstractString,
@@ -138,7 +138,7 @@ function OpenAI.create_chat(schema::MistralOpenAISchema,
         url::String = "https://api.mistral.ai/v1",
         kwargs...)
     # try to override provided api_key because the default is OpenAI key
-    api_key = isempty(MISTRALAI_API_KEY) ? api_key : MISTRALAI_API_KEY
+    api_key = isempty(MISTRAL_API_KEY) ? api_key : MISTRAL_API_KEY
     OpenAI.create_chat(CustomOpenAISchema(), api_key, model, conversation; url, kwargs...)
 end
 function OpenAI.create_chat(schema::FireworksOpenAISchema,
@@ -329,7 +329,7 @@ function OpenAI.create_embeddings(schema::MistralOpenAISchema,
     # Build the corresponding provider object
     # try to override provided api_key because the default is OpenAI key
     provider = CustomProvider(;
-        api_key = isempty(MISTRALAI_API_KEY) ? api_key : MISTRALAI_API_KEY,
+        api_key = isempty(MISTRAL_API_KEY) ? api_key : MISTRAL_API_KEY,
         base_url = url)
     OpenAI.create_embeddings(provider, docs, model; kwargs...)
 end

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -190,8 +190,11 @@ function load_api_keys!()
     AZURE_OPENAI_HOST = @load_preference("AZURE_OPENAI_HOST",
         default=get(ENV, "AZURE_OPENAI_HOST", ""))
     global MISTRAL_API_KEY
-    MISTRAL_API_KEY = @load_preference("MISTRAL_API_KEY",
-        default=get(ENV, "MISTRAL_API_KEY", ""))
+    MISTRAL_API_KEY = @load_preference("MISTRAL_API_KEY", 
+        default=get(ENV, "MISTRAL_API_KEY", 
+            get(ENV, "MISTRALAI_API_KEY", "")))
+    if !isempty(get(ENV, "MISTRALAI_API_KEY", ""))
+        @warn "The MISTRALAI_API_KEY environment variable is deprecated. Use MISTRAL_API_KEY instead."
     global COHERE_API_KEY
     COHERE_API_KEY = @load_preference("COHERE_API_KEY",
         default=get(ENV, "COHERE_API_KEY", ""))

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -195,6 +195,7 @@ function load_api_keys!()
             get(ENV, "MISTRALAI_API_KEY", "")))
     if !isempty(get(ENV, "MISTRALAI_API_KEY", ""))
         @warn "The MISTRALAI_API_KEY environment variable is deprecated. Use MISTRAL_API_KEY instead."
+    end
     global COHERE_API_KEY
     COHERE_API_KEY = @load_preference("COHERE_API_KEY",
         default=get(ENV, "COHERE_API_KEY", ""))

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -13,7 +13,7 @@ Check your preferences by calling `get_preferences(key::String)`.
 - `OPENAI_API_KEY`: The API key for the OpenAI API. See [OpenAI's documentation](https://platform.openai.com/docs/quickstart?context=python) for more information.
 - `AZURE_OPENAI_API_KEY`: The API key for the Azure OpenAI API. See [Azure OpenAI's documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference) for more information.
 - `AZURE_OPENAI_HOST`: The host for the Azure OpenAI API. See [Azure OpenAI's documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference) for more information.
-- `MISTRALAI_API_KEY`: The API key for the Mistral AI API. See [Mistral AI's documentation](https://docs.mistral.ai/) for more information.
+- `MISTRAL_API_KEY`: The API key for the Mistral AI API. See [Mistral AI's documentation](https://docs.mistral.ai/) for more information.
 - `COHERE_API_KEY`: The API key for the Cohere API. See [Cohere's documentation](https://docs.cohere.com/docs/the-cohere-platform) for more information.
 - `DATABRICKS_API_KEY`: The API key for the Databricks Foundation Model API. See [Databricks' documentation](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html) for more information.
 - `DATABRICKS_HOST`: The host for the Databricks API. See [Databricks' documentation](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html) for more information.
@@ -46,7 +46,7 @@ Define your `register_model!()` calls in your `startup.jl` file to make them ava
 - `OPENAI_API_KEY`: The API key for the OpenAI API. 
 - `AZURE_OPENAI_API_KEY`: The API key for the Azure OpenAI API. 
 - `AZURE_OPENAI_HOST`: The host for the Azure OpenAI API. This is the URL built as `https://<resource-name>.openai.azure.com`.
-- `MISTRALAI_API_KEY`: The API key for the Mistral AI API.
+- `MISTRAL_API_KEY`: The API key for the Mistral AI API.
 - `COHERE_API_KEY`: The API key for the Cohere API.
 - `LOCAL_SERVER`: The URL of the local server to use for `ai*` calls. Defaults to `http://localhost:10897/v1`. This server is called when you call `model="local"`
 - `DATABRICKS_API_KEY`: The API key for the Databricks Foundation Model API.
@@ -70,7 +70,7 @@ WARNING: NEVER EVER sync your `LocalPreferences.toml` file! It contains your API
 const PREFERENCES = nothing
 
 "Keys that are allowed to be set via `set_preferences!`"
-const ALLOWED_PREFERENCES = ["MISTRALAI_API_KEY",
+const ALLOWED_PREFERENCES = ["MISTRAL_API_KEY",
     "OPENAI_API_KEY",
     "AZURE_OPENAI_API_KEY",
     "AZURE_OPENAI_HOST",
@@ -155,7 +155,7 @@ global MODEL_IMAGE_GENERATION::String = @load_preference("MODEL_IMAGE_GENERATION
 global OPENAI_API_KEY::String = ""
 global AZURE_OPENAI_API_KEY::String = ""
 global AZURE_OPENAI_HOST::String = ""
-global MISTRALAI_API_KEY::String = ""
+global MISTRAL_API_KEY::String = ""
 global COHERE_API_KEY::String = ""
 global DATABRICKS_API_KEY::String = ""
 global DATABRICKS_HOST::String = ""
@@ -189,9 +189,9 @@ function load_api_keys!()
     global AZURE_OPENAI_HOST
     AZURE_OPENAI_HOST = @load_preference("AZURE_OPENAI_HOST",
         default=get(ENV, "AZURE_OPENAI_HOST", ""))
-    global MISTRALAI_API_KEY
-    MISTRALAI_API_KEY = @load_preference("MISTRALAI_API_KEY",
-        default=get(ENV, "MISTRALAI_API_KEY", ""))
+    global MISTRAL_API_KEY
+    MISTRAL_API_KEY = @load_preference("MISTRAL_API_KEY",
+        default=get(ENV, "MISTRAL_API_KEY", ""))
     global COHERE_API_KEY
     COHERE_API_KEY = @load_preference("COHERE_API_KEY",
         default=get(ENV, "COHERE_API_KEY", ""))


### PR DESCRIPTION
MISTRALAI I think was deceptive, as everywhere out there it is called MISTRAL_API_KEY. 