### PR TITLE
update CI for 1.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         version:
           - '1.9'
           - '1.10'
-          # - '1.11'
+          - '1.11'
           # - 'nightly'
         os:
           - ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.65.2]
+
+### Fixed
+- Fixed a bug in `extract_docstring` where it would not correctly block "empty" docstrings on Julia 1.11.
+
+
 ## [0.65.1]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.65.1"
+version = "0.65.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/extraction.jl
+++ b/src/extraction.jl
@@ -182,7 +182,8 @@ function extract_docstring(
     ## we ignore the ones that are subtypes for now (to prevent picking up Dicts, etc.)
     if (type isa Type && (supertype(type) == Any)) || (type isa Function)
         docs = Docs.doc(type) |> string
-        if !occursin("No documentation found.\n\n", docs)
+        ## Covers two known cases: "No documentation found.\n\n" and "No documentation found for private symbol."
+        if !startswith(docs, "No documentation found")
             return first(docs, max_description_length)
         end
     end

--- a/test/Experimental/AgentTools/code_feedback.jl
+++ b/test/Experimental/AgentTools/code_feedback.jl
@@ -136,8 +136,10 @@ end
 
     # Test case 1: Test error_feedback with defined variable
     e = UndefVarError(:Threads)
-    expected_output = "UndefVarError: `Threads` not defined\nExpert Tip: I know that the variable Threads is defined in Base module. Use `import Base.Threads` to use it."
-    @test error_feedback(e) == expected_output
+    str = error_feedback(e)
+    @test occursin("UndefVarError: `Threads` not defined", str)
+    @test occursin(
+        "Expert Tip: I know that the variable Threads is defined in Base module.", str)
 
     # Test case 2: Test error_feedback with undefined variable
     e = UndefVarError(:SomeVariable)

--- a/test/code_eval.jl
+++ b/test/code_eval.jl
@@ -33,7 +33,8 @@ using PromptingTools: extract_module_name
       """)
         eval!(cb)
         @test cb.success == false
-        @test cb.error == UndefVarError(:b)
+        @test cb.error isa UndefVarError
+        @test cb.error.var == :b
         @test !isnothing(cb.expression) # parsed
     end
 
@@ -45,7 +46,8 @@ using PromptingTools: extract_module_name
     cb = eval!(cb)
     eval!(cb, cb.expression; capture_stdout = false)
     @test cb.success == false
-    @test cb.error == UndefVarError(:b)
+    @test cb.error isa UndefVarError
+    @test cb.error.var == :b
     @test cb.error_lines == [1]
     # despite not capturing stdout, we always unwrap the error to be able to detect error lines
     @test occursin("UndefVarError", cb.stdout)

--- a/test/extraction.jl
+++ b/test/extraction.jl
@@ -231,7 +231,6 @@ end
     @test get_arg_names(first(methods(f6))) == [:x, :y]
     @test get_arg_types(first(methods(f6))) == [Int, String]
 end
-
 @testset "to_json_schema" begin
     struct MyStruct
         field1::Int


### PR DESCRIPTION
- Fixed a bug in `extract_docstring` where it would not correctly block "empty" docstrings on Julia 1.11.