### PR TITLE
Add assertion for aiextract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Added assertion in `response_to_message` for missing `:tool_calls` key in the response message. It's model failure but it wasn't obvious from the original error.
 
 ## [0.69.0]
 

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -856,6 +856,7 @@ function response_to_message(schema::AbstractOpenAISchema,
         [parse_tool(
             tool.callable, content_obj)]
     else
+        @assert haskey(choice[:message], :tool_calls) "`:tool_calls` key is missing in the response message! Retry the request."
         ## If name does not match, we use the callable from the tool_map 
         ## Can happen only in testing with auto-generated struct
         [parse_tool(


### PR DESCRIPTION
- Added assertion in `response_to_message` for missing `:tool_calls` key in the response message. It's model failure but it wasn't obvious from the original error.