### PR TITLE
Add o3 mini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the new OpenAI's O3 Mini reasoning model to the model registry (alias `o3m`).
 - Added the new DeepSeek R1 Distill Llama 70b model hosted on GroqCloud, which beats GPT 4o in many benchmarks while being upto 10x cheaper (alias `glmr` - stands for Groq Llama Medium(70b) Reasoning).
+- Added experimental support for "thinking tokens" that can be found with DeepSeek API and the reasoning model R1 (alias `dsr`). If the thought chain is provided, we save it in the `msg.extras[:reasoning_content]` field for advanced users.
 
 ## [0.70.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.71.0]
+
+### Added
+- Added the new OpenAI's O3 Mini reasoning model to the model registry (alias `o3m`).
+- Added the new DeepSeek R1 Distill Llama 70b model hosted on GroqCloud, which beats GPT 4o in many benchmarks while being upto 10x cheaper (alias `glmr` - stands for Groq Llama Medium(70b) Reasoning).
+
 ## [0.70.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.70.0"
+version = "0.71.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/llm_openai.jl
+++ b/src/llm_openai.jl
@@ -176,6 +176,14 @@ function response_to_message(schema::AbstractOpenAISchema,
     else
         nothing
     end
+    ## Has reasoning content -- currently only provided by DeepSeek API
+    has_reasoning_content = haskey(choice, :message) &&
+                            haskey(choice[:message], :reasoning_content)
+    reasoning_content = if has_reasoning_content
+        choice[:message][:reasoning_content]
+    else
+        nothing
+    end
     # Extract usage information with default values for tokens
     tokens_prompt = 0
     tokens_completion = 0
@@ -190,9 +198,13 @@ function response_to_message(schema::AbstractOpenAISchema,
     end
     ## calculate cost
     cost = call_cost(tokens_prompt, tokens_completion, model_id)
+    ## Add extras, usually keys that are provider-specific
     extras = Dict{Symbol, Any}()
     if has_log_prob
         extras[:log_prob] = choice[:logprobs]
+    end
+    if has_reasoning_content
+        extras[:reasoning_content] = reasoning_content
     end
     ## build AIMessage object
     msg = MSG(;
@@ -856,6 +868,14 @@ function response_to_message(schema::AbstractOpenAISchema,
     else
         nothing
     end
+    ## Has reasoning content -- currently only provided by DeepSeek API
+    has_reasoning_content = haskey(choice, :message) &&
+                            haskey(choice[:message], :reasoning_content)
+    reasoning_content = if has_reasoning_content
+        choice[:message][:reasoning_content]
+    else
+        nothing
+    end
     # Extract usage information with default values for tokens
     tokens_prompt = 0
     tokens_completion = 0
@@ -893,6 +913,9 @@ function response_to_message(schema::AbstractOpenAISchema,
     end
     if has_log_prob
         extras[:log_prob] = choice[:logprobs]
+    end
+    if has_reasoning_content
+        extras[:reasoning_content] = reasoning_content
     end
 
     ## build DataMessage object
@@ -1512,6 +1535,14 @@ function response_to_message(schema::AbstractOpenAISchema,
     else
         nothing
     end
+    ## Has reasoning content -- currently only provided by DeepSeek API
+    has_reasoning_content = haskey(choice, :message) &&
+                            haskey(choice[:message], :reasoning_content)
+    reasoning_content = if has_reasoning_content
+        choice[:message][:reasoning_content]
+    else
+        nothing
+    end
     # Extract usage information with default values for tokens
     tokens_prompt = 0
     tokens_completion = 0
@@ -1560,6 +1591,9 @@ function response_to_message(schema::AbstractOpenAISchema,
     end
     if has_log_prob
         extras[:log_prob] = choice[:logprobs]
+    end
+    if has_reasoning_content
+        extras[:reasoning_content] = reasoning_content
     end
 
     ## build AIToolRequest object

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -386,6 +386,7 @@ aliases = merge(
         "o1" => "o1",
         "o1p" => "o1-preview",
         "o1m" => "o1-mini",
+        "o3m" => "o3-mini",
         "ada" => "text-embedding-ada-002",
         "emb3small" => "text-embedding-3-small",
         "emb3large" => "text-embedding-3-large",
@@ -453,6 +454,7 @@ aliases = merge(
         "glxs" => "llama-3.2-3b-preview", #xs for extra small
         "gls" => "llama-3.1-8b-instant", #s for small
         "glm" => "llama-3.3-70b-versatile", #m for medium
+        "glmr" => "DeepSeek-R1-Distill-Llama-70b", #r R1 Distill
         "glms" => "llama-3.3-70b-specdec", #ms for medium speculative decoding
         "gll" => "llama-3.1-405b-reasoning", #l for large
         "gmixtral" => "mixtral-8x7b-32768",
@@ -609,6 +611,16 @@ registry = Dict{String, ModelSpec}(
         1.5e-5,
         6e-5,
         "O1 is the latest version of OpenAI's O1 model. 200K context, 100K output."),
+    "o3-mini" => ModelSpec("o3-mini",
+        OpenAISchema(),
+        1.5e-5,
+        6e-5,
+        "O3 Mini is the latest version of OpenAI's O3 model. 200K context, 100K output."),
+    "o3-mini-2025-01-31" => ModelSpec("o3-mini-2025-01-31",
+        OpenAISchema(),
+        1.1e-6,
+        4.4e-6,
+        "O3 Mini is the latest version of OpenAI's O3 reasoning model. 200K context, 100K output."),
     "chatgpt-4o-latest" => ModelSpec("chatgpt-4o-latest",
         OpenAISchema(),
         5e-6,
@@ -1008,6 +1020,11 @@ registry = Dict{String, ModelSpec}(
         2.4e-5,
         "Anthropic's Claude 2.1 model."),
     ## Groq -- using preliminary pricing on https://wow.groq.com/
+    "DeepSeek-R1-Distill-Llama-70b" => ModelSpec("DeepSeek-R1-Distill-Llama-70b",
+        GroqOpenAISchema(),
+        5.9e-7,
+        7.9e-7,
+        "DeepSeek's R1 Distill Llama 70b, hosted by Groq. Context 128K tokens. See details [here](https://console.groq.com/docs/models)"),
     "llama-3.3-70b-specdec" => ModelSpec("llama-3.3-70b-specdec",
         GroqOpenAISchema(),
         5.9e-7,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -472,7 +472,17 @@ function _report_stats(msg,
     cost = call_cost(msg, model)
     cost_str = iszero(cost) ? "" : " @ Cost: \$$(round(cost; digits=4))"
     metadata_str = if !isnothing(msg.extras) && !isempty(msg.extras)
-        " (Metadata: $(join([string(k, " => ", v) for (k, v) in msg.extras if v isa Number && !iszero(v)], ", ")))"
+        numeric_keys = join(
+            [string(k, " => ", v)
+             for (k, v) in msg.extras if v isa Number && !iszero(v)],
+            ", ")
+        other_keys = join(
+            [string(k)
+             for (k, v) in msg.extras if !(v isa Number && !iszero(v))],
+            ", ")
+        other_keys_str = !isempty(other_keys) && !isempty(numeric_keys) ?
+                         ", Other keys: $(other_keys)" : other_keys
+        " (Metadata: $(numeric_keys)$(other_keys_str))"
     else
         ""
     end

--- a/test/llm_openai.jl
+++ b/test/llm_openai.jl
@@ -932,6 +932,7 @@ end
                 :name => "RandomType1235"))
             ]),
         :logprobs => Dict(:content => [Dict(:logprob => -0.5), Dict(:logprob => -0.4)]),
+        :reasoning_content => "Reasoning content",
         :finish_reason => "stop")
     ## Test with a single sample
     response = Dict(:choices => [mock_choice],
@@ -942,6 +943,7 @@ end
         api_kwargs = (; temperature = 0, n = 2))
     @test msg.content == RandomType1235(1)
     @test msg.log_prob ≈ -0.9
+    @test msg.extras[:reasoning_content] == "Reasoning content"
 
     ## Test with field descriptions
     fields = [:x => Int, :x__description => "Field 1 description"]
@@ -1081,6 +1083,7 @@ end
         :choices => [
             Dict(
             :message => Dict(:content => "",
+                :reasoning_content => "Reasoning content",
                 :tool_calls => [
                     Dict(:id => "123",
                     :function => Dict(
@@ -1107,6 +1110,7 @@ end
     @test msg_single.tool_calls[1].args[:location] == "New York"
     @test msg_single.tool_calls[1].args[:date] == "2023-05-01"
     @test msg_single.tokens == (15, 5)
+    @test msg_single.extras[:reasoning_content] == "Reasoning content"
 
     # Mock response for multiple tool calls
     multi_tool_response = Dict(
@@ -1215,7 +1219,9 @@ end
             :logprobs => Dict(:content => [
                 Dict(:logprob => -0.1),
                 Dict(:logprob => -0.2)
-            ]))
+            ]),
+            ## Only for DeepSeek API
+            :reasoning_content => "Reasoning content")
         ],
         :usage => Dict(:total_tokens => 3, :prompt_tokens => 2, :completion_tokens => 1))
     schema1 = TestEchoOpenAISchema(; response, status = 200)
@@ -1225,7 +1231,7 @@ end
         api_kwargs = (; temperature = 0))
     @test msg.content == "Hello1!"
     @test msg.log_prob ≈ -0.3
-
+    @test msg.extras[:reasoning_content] == "Reasoning content"
     ## Test multiple samples
     response = Dict(
         :choices => [

--- a/test/llm_openai.jl
+++ b/test/llm_openai.jl
@@ -926,14 +926,13 @@ end
 
     mock_choice = Dict(
         :message => Dict(:content => "Hello!",
+            :reasoning_content => "Reasoning content",
             :tool_calls => [
                 Dict(:function => Dict(
                 :arguments => JSON3.write(Dict(:x => 1)),
                 :name => "RandomType1235"))
             ]),
-        :logprobs => Dict(:content => [Dict(:logprob => -0.5), Dict(:logprob => -0.4)]),
-        :reasoning_content => "Reasoning content",
-        :finish_reason => "stop")
+        :logprobs => Dict(:content => [Dict(:logprob => -0.5), Dict(:logprob => -0.4)]), :finish_reason => "stop")
     ## Test with a single sample
     response = Dict(:choices => [mock_choice],
         :usage => Dict(:total_tokens => 3, :prompt_tokens => 2, :completion_tokens => 1))
@@ -1214,14 +1213,16 @@ end
     ## Test with single sample and log_probs samples
     response = Dict(
         :choices => [
-            Dict(:message => Dict(:content => "Hello1!"),
+            Dict(
+            :message => Dict(:content => "Hello1!",
+                ## Only for DeepSeek API
+                :reasoning_content => "Reasoning content"),
             :finish_reason => "stop",
             :logprobs => Dict(:content => [
                 Dict(:logprob => -0.1),
                 Dict(:logprob => -0.2)
-            ]),
-            ## Only for DeepSeek API
-            :reasoning_content => "Reasoning content")
+            ])
+        )
         ],
         :usage => Dict(:total_tokens => 3, :prompt_tokens => 2, :completion_tokens => 1))
     schema1 = TestEchoOpenAISchema(; response, status = 200)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -252,6 +252,11 @@ end
             :cache_read_input_tokens => 100, :cache_creation_input_tokens => 200))
     expected_output = "Tokens: 6000 @ Cost: \$0.008 in 5.0 seconds (Metadata: cache_read_input_tokens => 100, cache_creation_input_tokens => 200)"
     @test _report_stats(msg, "gpt-3.5-turbo") == expected_output
+    # Test with extra key that has no numeric value
+    msg = AIMessage(; content = "", tokens = (1000, 5000), elapsed = 5.0,
+        extras = Dict{Symbol, Any}(:extra_key1 => "value1"))
+    expected_output = "Tokens: 6000 @ Cost: \$0.008 in 5.0 seconds (Metadata: extra_key1)"
+    @test _report_stats(msg, "gpt-3.5-turbo") == expected_output
 end
 
 @testset "_string_to_vector" begin


### PR DESCRIPTION
- Added the new OpenAI's O3 Mini reasoning model to the model registry (alias `o3m`).
- Added the new DeepSeek R1 Distill Llama 70b model hosted on GroqCloud, which beats GPT 4o in many benchmarks while being upto 10x cheaper (alias `glmr` - stands for Groq Llama Medium(70b) Reasoning).
