### PR TITLE
Update alias for open router models for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.72.1]
 
 ### Added
-- Added Qwen models from OpenRouter API: Qwen Turbo, Plus and Max models with competitive pricing and 128K context window.
+- Added Qwen models from OpenRouter API: Qwen Turbo, Plus and Max models with competitive pricing and 128K context window (aliases `orqwenturbo`, `orqwenplus` and `orqwenmax`, respectively).
 
 ## [0.72.0]
 

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -500,9 +500,9 @@ aliases = merge(
         "oro1m" => "openai/o1-mini",
         "orcop" => "cohere/command-r-plus-08-2024",
         "orco" => "cohere/command-r-08-2024",
-        "oqwenturbo" => "qwen/qwen-turbo",
-        "oqwenplus" => "qwen/qwen-plus",
-        "oqwenmax" => "qwen/qwen-max",
+        "orqwenturbo" => "qwen/qwen-turbo",
+        "orqwenplus" => "qwen/qwen-plus",
+        "orqwenmax" => "qwen/qwen-max",
         ## Gemini 1.5 Models
         "gem15p" => "gemini-1.5-pro-latest",
         "gem15f8" => "gemini-1.5-flash-8b-latest",
@@ -1180,9 +1180,8 @@ registry = Dict{String, ModelSpec}(
         OpenRouterOpenAISchema(),
         1.6e-6,
         6.4e-6,
-        "OpenRouter's hosted version of Qwen's latest and strongest model Qwen-Plus. 128K context, max output 8K tokens."),
-
-    "cohere/command-r-08-2024" => ModelSpec("cohere/command-r-08-2024",
+        "OpenRouter's hosted version of Qwen's latest and strongest model Qwen-Plus. 128K context, max output 8K tokens."), "cohere/command-r-08-2024" => ModelSpec(
+        "cohere/command-r-08-2024",
         OpenRouterOpenAISchema(),
         1.5e-7,
         6e-7,


### PR DESCRIPTION
Changed oqwen -> orqwen ("or" for openrouter hosted models)