### PR TITLE
Add custom retry layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.73.0]
+
+### Added
+- Added a new `enable_retry!` function to enable the retry layer for HTTP requests. Main use case is to prevent rate limiting errors from external AI services, but you can fully customize the retry behavior for any HTTP status codes, etc. See `?enable_retry!` for more information.
+
 ## [0.72.3]
 
 ### Added

--- a/examples/using_retry_layer.jl
+++ b/examples/using_retry_layer.jl
@@ -1,41 +1,115 @@
-## The Simplest workflow
+# # Using the Retry Layer
+#
+# The retry layer automatically handles temporary API failures by retrying requests that fail with specific 
+# HTTP status codes (like rate limiting). This is especially useful when working with external AI services 
+# that might have usage limits or temporary availability issues.
+
+# ## The Simplest workflow
 using PromptingTools
-# Enable the custom retry layer
-custom_retry_layer!(true)
-# Any rate limiting / rate limit errors will be retried automatically
+
+# Enable the retry layer with default settings (retries 429 status codes)
+# This adds a middleware layer to HTTP requests that will automatically retry when rate limited
+enable_retry!()
+
+# Any rate limiting errors (status code 429) will be retried automatically
+# The system will use exponential backoff to wait progressively longer between retries
 aigenerate("What is the meaning of life?")
-# Uninstall with / remove it with
-custom_retry_layer!(false)
 
-## More Advanced use
-using HTTP
+# Disable the retry layer when done
+# This removes the middleware from the HTTP request pipeline
+enable_retry!(false)
+
+## Advanced usage: Configuring global defaults -- only before the first call to `custom_retry_layer`!
 using PromptingTools
+using HTTP
 
-# Let's push the layer globally in all HTTP.jl requests
-HTTP.pushlayer!(PromptingTools.CustomRetryLayer.custom_retry_layer, request = true) # for stream handling, we would set request=false
+# Enable with custom global defaults
+enable_retry!(;
+    max_retries = 3,                   # Maximum 3 retry attempts (default is 5)
+    base_delay = 1.0,                  # Start with 1 second delay (default is 2.0)
+    status_codes = [429, 503, 504],    # Retry on rate limits and server errors
+    show_headers = false               # Don't show headers in warning messages
+)
 
-# Let's call the API - it fails with 404 Not Found (bad model name)
-msg = aigenerate("What is the meaning of life?", model = "bad-name")
+# All subsequent requests will use these global defaults
+aigenerate("What is the meaning of life?")
 
-# Let's catch the 404 error in retry loop to demonstrate the retry logic
-msg = aigenerate("What is the meaning of life?", model = "bad-name",
-    http_kwargs = (; custom_retry_status_codes = [404]))
+# ## Per-request customization
+# Override specific settings for a single request
+msg = aigenerate("Write a poem about AI",
+    http_kwargs = (;
+        custom_retry_max_retries = 10,         # Try harder for this request
+        custom_retry_status_codes = [429, 404] # Also retry on 404 errors
+    )
+)
 
-# We can temporarily disable the custom retry logic by setting custom_retry_enabled = false
-msg = aigenerate("What is the meaning of life?", model = "bad-name",
-    http_kwargs = (; custom_retry_enabled = false))
+# Temporarily disable retries for a specific request
+msg = aigenerate("What is 2+2?",
+    http_kwargs = (; custom_retry_enabled = false)
+)
 
-# We can also remove the layer completely
-HTTP.poplayer!() # you should see it pop off the stack
+# ## Low-level HTTP layer management
+# Check which layers are currently installed
+println("Current HTTP request layers: ", HTTP.REQUEST_LAYERS)
 
-# The layer is generally in either `HTTP.REQUEST_LAYERS` or `HTTP.STREAM_LAYERS`, depending on whether you set `request=true` or `request=false` in the `pushlayer!` call.
+# Manually remove the retry layer
+enable_retry!(false)
 
-# There is much more to customize, eg, `custom_retry_max_retries`, `custom_retry_base_delay`, `custom_retry_status_codes`).
-msg = aigenerate("What is the meaning of life?", model = "bad-name",
-    http_kwargs = (; custom_retry_status_codes = [429]))
+# Manually install the retry layer for stream requests instead of request handlers
+# This affects streaming API calls rather than standard requests
+enable_retry!(; request = false)
 
-# You can also use the convenience function `custom_retry_layer!` to enable/disable the custom retry layer.
-custom_retry_layer!(true)
+# Remove from stream layers
+enable_retry!(false; request = false)
 
-# Disable the custom retry layer
-custom_retry_layer!(false)
+## Note on configuration hierarchy (from lowest to highest priority):
+# 1. Default values in CustomRetryConfig
+# 2. Values set with enable_retry!() function
+# 3. Per-request values in http_kwargs
+#
+# This means that per-request settings always override global settings, which override defaults.
+
+# ## How It Works
+#
+# The retry layer is implemented as a middleware component in Julia's HTTP.jl package.
+# Here's how the implementation works under the hood:
+#
+# ### HTTP Layer Stack
+# HTTP.jl uses a layered approach for request processing. Each layer can modify 
+# requests/responses or implement specific behaviors like retrying or logging.
+# 
+# - The retry layer is inserted into this stack using `HTTP.pushlayer!()`
+# - When disabled, it's removed with `HTTP.poplayer!()`
+# - Layers are executed in order, with each having the opportunity to handle requests/responses
+#
+# ### Retry Logic Implementation
+#
+# When a request fails with a specified status code, the retry layer:
+#
+# 1. Examines response headers to determine wait time:
+#    - Looks for headers like `Retry-After`, `RateLimit-Reset`, or `X-RateLimit-Reset`
+#    - These headers often indicate how long to wait before trying again
+#
+# 2. If no specific wait time is found, uses exponential backoff:
+#    - Starts with `base_delay` (default: 2 seconds)
+#    - Each subsequent retry multiplies this by 2 (plus some jitter)
+#    - This prevents overwhelming the API with immediate retry attempts
+#
+# ### Concurrency Control
+#
+# To handle multiple concurrent requests gracefully:
+#
+# - A global `ReentrantLock` is used to coordinate all retry attempts
+# - This ensures that even highly concurrent applications respect rate limits
+# - When one thread is delayed due to rate limiting, other threads will also be throttled
+# - This prevents the "thundering herd" problem where multiple threads hit rate limits simultaneously
+#
+# ### Best Practices
+#
+# 1. Enable the retry layer early in your application startup
+# 2. Configure global defaults appropriately for your API provider
+# 3. Adjust per-request settings only when necessary for specific calls
+# 4. Consider disabling the retry layer when making time-sensitive requests where retrying might be harmful
+#
+# The retry system is designed to be unobtrusive while providing robust handling of 
+# temporary failures, especially for long-running processes or batch operations.

--- a/examples/using_retry_layer.jl
+++ b/examples/using_retry_layer.jl
@@ -1,0 +1,31 @@
+using HTTP
+using PromptingTools
+
+# Let's push the layer globally in all HTTP.jl requests
+HTTP.pushlayer!(PromptingTools.CustomRetryLayer.custom_retry_layer, request = true) # for stream handling, we would set request=false
+
+# Let's call the API - it fails with 404 Not Found (bad model name)
+msg = aigenerate("What is the meaning of life?", model = "bad-name")
+
+# Let's catch the 404 error in retry loop to demonstrate the retry logic
+msg = aigenerate("What is the meaning of life?", model = "bad-name",
+    http_kwargs = (; custom_retry_status_codes = [404]))
+
+# We can temporarily disable the custom retry logic by setting custom_retry_enabled = false
+msg = aigenerate("What is the meaning of life?", model = "bad-name",
+    http_kwargs = (; custom_retry_enabled = false))
+
+# We can also remove the layer completely
+HTTP.poplayer!() # you should see it pop off the stack
+
+# The layer is generally in either `HTTP.REQUEST_LAYERS` or `HTTP.STREAM_LAYERS`, depending on whether you set `request=true` or `request=false` in the `pushlayer!` call.
+
+# There is much more to customize, eg, `custom_retry_max_retries`, `custom_retry_base_delay`, `custom_retry_status_codes`).
+msg = aigenerate("What is the meaning of life?", model = "bad-name",
+    http_kwargs = (; custom_retry_status_codes = [429]))
+
+# You can also use the convenience function `custom_retry_layer!` to enable/disable the custom retry layer.
+custom_retry_layer!(true)
+
+# Disable the custom retry layer
+custom_retry_layer!(false)

--- a/examples/using_retry_layer.jl
+++ b/examples/using_retry_layer.jl
@@ -1,3 +1,13 @@
+## The Simplest workflow
+using PromptingTools
+# Enable the custom retry layer
+custom_retry_layer!(true)
+# Any rate limiting / rate limit errors will be retried automatically
+aigenerate("What is the meaning of life?")
+# Uninstall with / remove it with
+custom_retry_layer!(false)
+
+## More Advanced use
 using HTTP
 using PromptingTools
 

--- a/src/PromptingTools.jl
+++ b/src/PromptingTools.jl
@@ -108,6 +108,10 @@ include("llm_anthropic.jl")
 include("llm_sharegpt.jl")
 include("llm_tracer.jl")
 
+## Custom retry layer
+include("retry_layer.jl")
+using .CustomRetryLayer: custom_retry_layer!
+
 ## Convenience utils
 export @ai_str, @aai_str, @ai!_str, @aai!_str
 include("macros.jl")

--- a/src/PromptingTools.jl
+++ b/src/PromptingTools.jl
@@ -110,7 +110,7 @@ include("llm_tracer.jl")
 
 ## Custom retry layer
 include("retry_layer.jl")
-using .CustomRetryLayer: custom_retry_layer!
+using .CustomRetryLayer: enable_retry!
 
 ## Convenience utils
 export @ai_str, @aai_str, @ai!_str, @aai!_str

--- a/src/retry_layer.jl
+++ b/src/retry_layer.jl
@@ -1,0 +1,347 @@
+# ## Create Retry Layer
+## Define the new retry mechanism as a layer for HTTP
+## See documentation [here](https://juliaweb.github.io/HTTP.jl/stable/client/#Quick-Examples)
+"""
+    CustomRetryLayer
+
+Custom retry layer for HTTP.jl. Once installed, it will catch all errors with status codes 429, 404, 503 and retry with exponential backoff (can be customized).
+
+# Examples
+```julia
+using HTTP
+using PromptingTools
+
+# Let's push the layer globally in all HTTP.jl requests
+HTTP.pushlayer!(PromptingTools.CustomRetryLayer.custom_retry_layer, request=true) # for stream handling, we would set request=false
+
+# Let's call the API - it fails with 404 Not Found (bad model name)
+msg = aigenerate("What is the meaning of life?", model = "bad-name")
+
+# Let's catch the 404 error in retry loop to demonstrate the retry logic
+msg = aigenerate("What is the meaning of life?", model = "bad-name", http_kwargs = (; custom_retry_status_codes = [404]))
+
+# We can temporarily disable the custom retry logic by setting custom_retry_enabled = false
+msg = aigenerate("What is the meaning of life?", model = "bad-name", http_kwargs = (; custom_retry_enabled = false))
+```
+
+We can also remove the layer completely
+```julia
+HTTP.poplayer!() # you should see it pop off the stack
+```
+
+The layer is generally in either `HTTP.REQUEST_LAYERS` or `HTTP.STREAM_LAYERS`, depending on whether you set `request=true` or `request=false` in the `pushlayer!` call.
+
+There is much more to customize, eg, `custom_retry_max_retries`, `custom_retry_base_delay`, `custom_retry_status_codes`).
+```julia
+msg = aigenerate("What is the meaning of life?", model = "bad-name", http_kwargs = (; custom_retry_status_codes = [429]))
+```
+"""
+module CustomRetryLayer
+
+using HTTP, JSON3
+using Dates
+
+# Global state to track rate limiting
+mutable struct RateLimitState
+    paused_until::Union{DateTime, Nothing}
+    mutex::ReentrantLock
+end
+
+# Initialize the global state
+const RATE_LIMIT_STATE = RateLimitState(nothing, ReentrantLock())
+
+"""
+    is_paused()
+
+Check if requests should be paused due to rate limiting.
+Returns a tuple (is_paused, seconds_remaining) where:
+- is_paused: Boolean indicating if requests should be paused
+- seconds_remaining: How many seconds to wait if paused
+"""
+function is_paused()::Tuple{Bool, Float64}
+    lock(RATE_LIMIT_STATE.mutex) do
+        if isnothing(RATE_LIMIT_STATE.paused_until)
+            return false, 0.0
+        end
+
+        now_time = now()
+        if now_time < RATE_LIMIT_STATE.paused_until
+            seconds_remaining = float(Dates.value(RATE_LIMIT_STATE.paused_until -
+                                                  now_time)) / 1000.0
+            return true, seconds_remaining
+        else
+            # Reset the pause state since we're past the pause time
+            RATE_LIMIT_STATE.paused_until = nothing
+            return false, 0.0
+        end
+    end
+end
+
+"""
+    pause_requests(seconds::Float64)
+
+Pause all requests for the specified number of seconds.
+"""
+function pause_requests(seconds::Float64)
+    lock(RATE_LIMIT_STATE.mutex) do
+        pause_until = now() + Dates.Millisecond(round(Int, seconds * 1000))
+
+        # Only update if the new pause time is later than any existing pause
+        if isnothing(RATE_LIMIT_STATE.paused_until) ||
+           pause_until > RATE_LIMIT_STATE.paused_until
+            RATE_LIMIT_STATE.paused_until = pause_until
+            @info "All requests paused until $(RATE_LIMIT_STATE.paused_until) ($(round(seconds, digits=2))s)"
+        end
+    end
+end
+
+"""
+    parse_time_string(time_str::AbstractString)
+
+Parses a time string like "1s", "6m0s", "1m30s", "500ms", or "1m30s500ms" into seconds.
+Returns the time in seconds as a Float64, or `nothing` if parsing fails.
+"""
+function parse_time_string(time_str::AbstractString)::Union{Float64, Nothing}
+    total_seconds = 0.0
+    remaining = time_str
+
+    # Match milliseconds first (to avoid confusion with minutes)
+    ms_match = match(r"(\d+(\.\d+)?)ms", remaining)
+    if !isnothing(ms_match)
+        milliseconds = parse(Float64, ms_match.captures[1])
+        total_seconds += milliseconds / 1000.0
+        remaining = replace(remaining, ms_match.match => "")
+    end
+
+    # Match minutes (now safe since we've already handled milliseconds)
+    m_match = match(r"(\d+)m(?!s)", remaining)
+    if !isnothing(m_match)
+        minutes = parse(Float64, m_match.captures[1])
+        total_seconds += minutes * 60
+        remaining = replace(remaining, m_match.match => "")
+    end
+
+    # Match seconds
+    s_match = match(r"(\d+(\.\d+)?)s(?!ms)", remaining)
+    if !isnothing(s_match)
+        seconds = parse(Float64, s_match.captures[1])
+        total_seconds += seconds
+        remaining = replace(remaining, s_match.match => "")
+    end
+
+    # Check if we found any time components
+    if ms_match === nothing && m_match === nothing && s_match === nothing
+        return nothing  # No valid time components found, return nothing
+    else
+        return total_seconds  # Return the total seconds, even if it's 0.0
+    end
+end
+
+"""
+    extract_retry_after(headers::Dict{String, String})
+
+Extracts the retry-after time in seconds from the headers.
+
+It checks for the following headers in order of priority:
+1. `retry-after-ms` (milliseconds)
+2.  `retry-after` (seconds)
+3.  `X-Ratelimit-Reset` (seconds)
+4.  `x-ratelimit-reset-requests` (seconds/minutes/both)
+5.  `x-ratelimit-reset-tokens` (seconds/minutes/both)
+
+Returns the retry-after time in seconds as a Float64, or `nothing` if no such header is found.
+"""
+function extract_retry_after(headers::Dict{String, String})::Union{Float64, Nothing}
+    if haskey(headers, "retry-after-ms")
+        return parse(Float64, headers["retry-after-ms"]) / 1000.0
+    elseif haskey(headers, "retry-after")
+        return parse(Float64, headers["retry-after"])
+    elseif haskey(headers, "X-Ratelimit-Reset")
+        return parse(Float64, headers["X-Ratelimit-Reset"])
+    else
+        # Check for the rate limit headers and parse them
+        reset_times = Float64[]
+        for header in ["x-ratelimit-reset-requests", "x-ratelimit-reset-tokens"]
+            if haskey(headers, header)
+                value = headers[header]
+                if occursin(r"[sm]", value)
+                    time = parse_time_string(value)
+                    if !isnothing(time)
+                        push!(reset_times, time)
+                    end
+                elseif all(isdigit, value)
+                    time = tryparse(Float64, value)
+                    if !isnothing(time)
+                        push!(reset_times, time)
+                    end
+                end
+            end
+        end
+
+        # Return the minimum reset time if any
+        if !isempty(reset_times)
+            return minimum(reset_times)
+        else
+            return nothing
+        end
+    end
+end
+
+"""
+    custom_retry_layer(
+        handler;
+        custom_retry_enabled::Bool = true,
+        custom_retry_max_retries::Int = 5,
+        custom_retry_base_delay::Float64 = 2.0,
+        custom_retry_status_codes = [429],
+        custom_retry_show_headers::Bool = true
+)
+
+HTTP-layer that retries requests with exponential backoff or with a delay specified in the headers.
+It pauses all requests globally (to not overwhelm the server when using `asyncmap`) when a rate limit is hit.
+
+By default, we only retry on 429 (rate limit hit) errors - most common issue with LLM providers.
+
+# Examples
+```julia
+using HTTP
+using PromptingTools    
+
+# Let's push the layer globally in all HTTP.jl requests
+HTTP.pushlayer!(PromptingTools.CustomRetryLayer.custom_retry_layer, request=true) # for stream handling, we would set request=false
+
+# All calls should have retry set for 429 errors
+msg = aigenerate("What is the meaning of life?")
+```
+"""
+function custom_retry_layer(
+        handler;
+        custom_retry_enabled::Bool = true,
+        custom_retry_max_retries::Int = 5,
+        custom_retry_base_delay::Float64 = 2.0,
+        custom_retry_status_codes = [429],
+        custom_retry_show_headers::Bool = true
+)
+    return function (req; kw...)
+        # If retries are disabled, just pass through to the handler
+        if !custom_retry_enabled
+            return handler(req; kw...)
+        end
+
+        # Check if requests are currently paused
+        paused, wait_time = is_paused()
+        if paused
+            @info "Request paused due to rate limiting. Waiting $(round(wait_time, digits=2)) seconds."
+            sleep(wait_time)
+        end
+
+        # Retry logic
+        num_retries = 0
+        while true
+            try
+                resp = handler(req; kw...)
+                return resp  # Success! Return the response
+            catch e
+                if e isa HTTP.Exceptions.StatusError
+                    status_code = e.status
+                    if status_code in custom_retry_status_codes
+                        num_retries += 1
+                        if num_retries > custom_retry_max_retries
+                            @error "Max retries reached. Failing the request."
+                            rethrow(e)  # Re-throw the exception
+                        end
+
+                        ## Custom behavior
+                        if status_code == 429
+                            # Try to extract the delay from the headers
+                            retry_after = extract_retry_after(Dict(string(k) => string(v)
+                            for (k, v) in e.response.headers))
+                            if !isnothing(retry_after) && retry_after > 0
+                                delay = retry_after
+                                @warn """
+                                    Rate limit hit (429). Pausing all requests for $(round(delay, digits=2)) seconds (attempt $num_retries/$custom_retry_max_retries) from headers.
+                                    $(custom_retry_show_headers ? """
+                                    Headers:
+                                    $(join(["$k: $v" for (k,v) in e.response.headers], "\n    "))
+                                    """ : "")
+                                    """
+                                # Pause all requests
+                                pause_requests(delay)
+                            else
+                                # Exponential backoff for rate limiting
+                                delay = custom_retry_base_delay * (2^(num_retries - 1)) +
+                                        rand()
+                                @warn """Rate limit hit (429). Pausing all requests for $(round(delay, digits=2)) seconds (attempt $num_retries/$custom_retry_max_retries) with exponential backoff.
+                                $(custom_retry_show_headers ? """
+                                Headers:
+                                $(join(["$k: $v" for (k,v) in e.response.headers], "\n    "))
+                                """ : "")
+                                """
+                                # Pause all requests
+                                pause_requests(delay)
+                            end
+                            sleep(delay)
+                        else
+                            delay = custom_retry_base_delay * (2^(num_retries - 1)) + rand()
+                            @warn """Status code $(status_code). Retrying in $(round(delay, digits=2)) seconds (attempt $num_retries/$custom_retry_max_retries).
+                            $(custom_retry_show_headers ? """
+                            Headers:
+                            $(join(["$k: $v" for (k,v) in e.response.headers], "\n    "))
+                            """ : "")
+                            """
+                            sleep(delay)
+                        end
+                    else
+                        # Not a 429 or 404, re-throw the exception
+                        rethrow(e)
+                    end
+                else
+                    # Not an HTTP error, re-throw the exception
+                    rethrow(e)
+                end
+            end
+        end
+        # pass the request along to the next layer by calling `cache_layer` arg `handler`
+        # also pass along the trailing keyword args `kw...`
+        return handler(req; kw...)
+    end
+end
+
+"""
+    custom_retry_layer!(enable::Bool = true; request::Bool = true)
+
+Enable or disable the custom retry layer. 
+A convenience function that only installs the layer in the HTTP.jl stack if it's not already installed.
+
+# Examples
+```julia
+using HTTP
+using PromptingTools
+
+# Enable the custom retry layer
+custom_retry_layer!(true)
+
+# Disable the custom retry layer
+custom_retry_layer!(false)
+```
+"""
+function custom_retry_layer!(enable::Bool = true; request::Bool = true)
+    # Get the appropriate layer stack based on request parameter
+    layer_stack = request ? HTTP.REQUEST_LAYERS : HTTP.STREAM_LAYERS
+    layer_pos = findfirst(layer -> layer == custom_retry_layer, layer_stack)
+
+    if enable && isnothing(layer_pos)
+        HTTP.pushlayer!(custom_retry_layer, request = request)
+    elseif enable
+        @warn "Custom retry layer is already in position $layer_pos of the $(request ? "request" : "stream") layer stack"
+    elseif !enable && !isnothing(layer_pos)
+        deleteat!(layer_stack, layer_pos)
+    else
+        @warn "Custom retry layer not found in the $(request ? "request" : "stream") layer stack"
+    end
+end
+
+# Create a new client with the retry layer added
+HTTP.@client [custom_retry_layer]
+
+end # module

--- a/test/retry_layer.jl
+++ b/test/retry_layer.jl
@@ -1,0 +1,214 @@
+using PromptingTools.CustomRetryLayer: enable_retry!, custom_retry_layer,
+                                       extract_retry_after, parse_time_string,
+                                       is_paused, pause_requests, RETRY_CONFIG,
+                                       RATE_LIMIT_STATE
+
+@testset "CustomRetryLayer" begin
+    # Save original config to restore later
+    original_max_retries = RETRY_CONFIG.max_retries
+    original_base_delay = RETRY_CONFIG.base_delay
+    original_status_codes = copy(RETRY_CONFIG.status_codes)
+    original_show_headers = RETRY_CONFIG.show_headers
+
+    # Test is_paused and pause_requests
+    @test !is_paused()[1]  # Initially not paused
+
+    pause_requests(0.2)  # Pause for a short time
+    paused, wait_time = is_paused()
+    @test paused  # Should be paused
+    @test wait_time > 0  # Should have some wait time
+
+    sleep(0.3)  # Wait for pause to expire
+    @test !is_paused()[1]  # Should no longer be paused
+
+    # Test enable_retry! configuration
+    enable_retry!(; max_retries = 10, base_delay = 3.0, status_codes = [429, 503])
+    @test RETRY_CONFIG.max_retries == 10
+    @test RETRY_CONFIG.base_delay == 3.0
+    @test RETRY_CONFIG.status_codes == [429, 503]
+
+    # Test enable_retry! layer management
+    enable_retry!(false)  # Disable first to ensure clean state
+    @test !any(layer -> layer == custom_retry_layer, HTTP.REQUEST_LAYERS)
+
+    enable_retry!()  # Enable with default settings
+    @test any(layer -> layer == custom_retry_layer, HTTP.REQUEST_LAYERS)
+
+    enable_retry!(false)  # Disable again
+    @test !any(layer -> layer == custom_retry_layer, HTTP.REQUEST_LAYERS)
+
+    # Test custom_retry_layer with mocked handler
+    # We'll create a mock handler that simulates different responses
+    retry_count = 0
+    function mock_handler(req; kw...)
+        if retry_count < 2
+            retry_count += 1
+            headers = [("retry-after", "0.1")]
+            resp = HTTP.Response(429, headers)
+            throw(HTTP.StatusError(429, req.method, req.target, resp))
+        else
+            return HTTP.Response(200)
+        end
+    end
+
+    # Test the retry layer with our mock handler
+    retry_layer = custom_retry_layer(
+        mock_handler;
+        custom_retry_max_retries = 3,
+        custom_retry_base_delay = 0.1,
+        custom_retry_status_codes = [429]
+    )
+
+    # Reset retry count
+    retry_count = 0
+
+    # The layer should retry and eventually succeed
+    resp = retry_layer(HTTP.Request("GET", "/"))
+    @test resp.status == 200
+    @test retry_count == 2  # Should have retried twice
+
+    # Test with retry disabled
+    retry_count = 0
+    retry_layer_disabled = custom_retry_layer(
+        mock_handler;
+        custom_retry_enabled = false
+    )
+
+    # Should throw immediately without retrying
+    @test_throws HTTP.StatusError retry_layer_disabled(HTTP.Request("GET", "/"))
+    @test retry_count == 1  # Should have only tried once
+
+    # Restore original config
+    RETRY_CONFIG.max_retries = original_max_retries
+    RETRY_CONFIG.base_delay = original_base_delay
+    RETRY_CONFIG.status_codes = original_status_codes
+    RETRY_CONFIG.show_headers = original_show_headers
+
+    # Make sure RATE_LIMIT_STATE is reset
+    RATE_LIMIT_STATE.paused_until = nothing
+end
+
+@testset "extract_retry_after" begin
+    # Test case 1: retry-after-ms
+    headers1 = Dict("retry-after-ms" => "2000")
+    @test extract_retry_after(headers1) == 2.0
+
+    # Test case 2: retry-after
+    headers2 = Dict("retry-after" => "5")
+    @test extract_retry_after(headers2) == 5.0
+
+    # Test case 3: X-Ratelimit-Reset
+    headers3 = Dict("X-Ratelimit-Reset" => "10")
+    @test extract_retry_after(headers3) == 10.0
+
+    # Test case 4: x-ratelimit-reset-requests (seconds)
+    headers4 = Dict("x-ratelimit-reset-requests" => "2s")
+    @test extract_retry_after(headers4) == 2.0
+
+    # Test case 5: x-ratelimit-reset-tokens (minutes and seconds)
+    headers5 = Dict("x-ratelimit-reset-tokens" => "1m30s")
+    @test extract_retry_after(headers5) == 90.0
+    headers5 = Dict("x-ratelimit-reset-tokens" => "10")
+    @test extract_retry_after(headers5) == 10.0
+
+    # Test case 6: x-ratelimit-reset-requests and x-ratelimit-reset-tokens (minimum)
+    headers6 = Dict(
+        "x-ratelimit-reset-requests" => "5s", "x-ratelimit-reset-tokens" => "2m")
+    @test extract_retry_after(headers6) == 5.0
+
+    # Test case 7: No headers
+    headers7 = Dict{String, String}()
+    @test isnothing(extract_retry_after(headers7))
+
+    # Test case 8: Invalid time string
+    headers8 = Dict("x-ratelimit-reset-requests" => "invalid")
+    @test isnothing(extract_retry_after(headers8))
+
+    # Test case 9: Only minutes
+    headers9 = Dict("x-ratelimit-reset-tokens" => "2m")
+    @test extract_retry_after(headers9) == 120.0
+
+    # Test case 10: Only seconds with decimal
+    headers10 = Dict("x-ratelimit-reset-requests" => "2.5s")
+    @test extract_retry_after(headers10) == 2.5
+
+    # Test case 11: Minutes and seconds with decimal
+    headers11 = Dict("x-ratelimit-reset-tokens" => "1m30.5s")
+    @test extract_retry_after(headers11) == 90.5
+
+    # Test case 12: Multiple ratelimit headers, one invalid
+    headers12 = Dict(
+        "x-ratelimit-reset-requests" => "5s", "x-ratelimit-reset-tokens" => "invalid")
+    @test extract_retry_after(headers12) == 5.0
+
+    # Test case 13: Milliseconds
+    headers13 = Dict("retry-after-ms" => "500")
+    @test extract_retry_after(headers13) == 0.5
+end
+
+@testset "parse_time_string" begin
+    # Test case 1: Seconds only
+    @test parse_time_string("5s") == 5.0
+
+    # Test case 2: Minutes only
+    @test parse_time_string("3m") == 180.0
+
+    # Test case 3: Minutes and seconds
+    @test parse_time_string("2m30s") == 150.0
+
+    # Test case 4: Decimal seconds
+    @test parse_time_string("1.5s") == 1.5
+
+    # Test case 5: Minutes and decimal seconds
+    @test parse_time_string("1m2.5s") == 62.5
+
+    # Test case 6: Invalid string
+    @test isnothing(parse_time_string("invalid"))
+
+    # Test case 7: Empty string
+    @test isnothing(parse_time_string(""))
+
+    # Test case 8: No time units
+    @test isnothing(parse_time_string("123"))
+
+    # Test case 9: Milliseconds only
+    @test parse_time_string("500ms") == 0.5
+
+    # Test case 10: Seconds and milliseconds
+    @test parse_time_string("2s500ms") == 2.5
+
+    # Test case 11: Minutes, seconds, and milliseconds
+    @test parse_time_string("1m30s500ms") == 90.5
+
+    # Test case 12: Decimal milliseconds
+    @test parse_time_string("1.5ms") == 0.0015
+
+    # Test case 13: Minutes and milliseconds (no seconds)
+    @test parse_time_string("2m500ms") == 120.5
+
+    # Test basic time formats
+    @test parse_time_string("1s") == 1.0
+    @test parse_time_string("1.5s") == 1.5
+    @test parse_time_string("1m") == 60.0
+    @test parse_time_string("500ms") == 0.5
+
+    # Test combined formats
+    @test parse_time_string("1m30s") == 90.0
+    @test parse_time_string("1m30s500ms") == 90.5
+    @test parse_time_string("30s500ms") == 30.5
+
+    # Test edge cases
+    @test parse_time_string("0s") == 0.0
+    @test parse_time_string("0m0s0ms") == 0.0
+    @test isnothing(parse_time_string("invalid"))
+
+    # Test potential ambiguous cases
+    @test parse_time_string("5m") == 300.0  # 5 minutes
+    @test parse_time_string("5ms") == 0.005  # 5 milliseconds
+
+    # Test with spaces (which the current implementation might not handle)
+    @test parse_time_string("1m 30s") == 90.0
+
+    # Test with unusual order
+    @test parse_time_string("500ms1m") == 60.5  # Should handle any order
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ end
     include("user_preferences.jl")
     include("llm_interface.jl")
     include("streaming.jl")
+    include("retry_layer.jl")
     include("llm_shared.jl")
     include("llm_openai.jl")
     include("llm_ollama_managed.jl")


### PR DESCRIPTION
This is a draft for adding a custom layer into the HTTP.jl stack that would affect ALL calls.
It would be available in Promptingtools and user could opt-in by installing this custom layer:

```
using PromptingTools

# Enable the custom retry layer
custom_retry_layer!(true)
# Any rate limiting / rate limit errors will be retried automatically
aigenerate("What is the meaning of life?")
```
Once installed, you can freely customize how many retries, which status codes it retries, etc. (see the example)

If you don't like, you can uninstall it: `custom_retry_layer!(false)`

Full example in `examples/using_retry_layer.jl`

Any thoughts? @Sixzero 