### PR TITLE
Add OpenAI's GPT 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.72.3]
+
+### Added
+- Added a OpenAI's GPT 4.5 research preview (alias `gpt45`) to the model registry.
+
 ## [0.72.2]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.72.2"
+version = "0.72.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -55,7 +55,7 @@ REPL = "<0.0.1, 1"
 Random = "<0.0.1, 1"
 SparseArrays = "<0.0.1, 1"
 Statistics = "<0.0.1, 1"
-StreamCallbacks = "0.5.1"
+StreamCallbacks = "0.5.2"
 Test = "<0.0.1, 1"
 julia = "1.9, 1.10"
 

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -382,6 +382,7 @@ aliases = merge(
         "gpt4v" => "gpt-4-vision-preview", # 4v is for "4 vision"
         "gpt4t" => "gpt-4-turbo", # 4t is for "4 turbo"
         "gpt3t" => "gpt-3.5-turbo-0125", # 3t is for "3 turbo"
+        "gpt45" => "gpt-4.5-preview", # 4.5 is for "4.5"
         "chatgpt" => "chatgpt-4o-latest",
         "o1" => "o1",
         "o1p" => "o1-preview",
@@ -564,6 +565,16 @@ registry = Dict{String, ModelSpec}(
         1e-5,
         3e-5,
         "GPT-4 Turbo is an updated version of GPT4 that is much faster and the cheaper to use. This is the general name for whatever is the latest GPT4 Turbo preview release. Right now it is 0125."),
+    "gpt-4.5-preview" => ModelSpec("gpt-4.5-preview",
+        OpenAISchema(),
+        7.5e-5,
+        1.5e-4,
+        "GPT-4.5 is the latest preview version of GPT4.5. It has 128K context, 16K output and is the largest model available on the OpenAI API."),
+    "gpt-4.5-preview-2025-02-27" => ModelSpec("gpt-4.5-preview-2025-02-27",
+        OpenAISchema(),
+        7.5e-5,
+        1.5e-4,
+        "GPT-4.5 is the latest preview version of GPT4.5. It has 128K context, 16K output and is the largest model available on the OpenAI API."),
     "gpt-4o-2024-05-13" => ModelSpec("gpt-4o-2024-05-13",
         OpenAISchema(),
         5e-6,

--- a/test/llm_anthropic.jl
+++ b/test/llm_anthropic.jl
@@ -525,7 +525,7 @@ end
     @test schema2.inputs.system == "Act as a helpful AI assistant"
     @test schema2.inputs.messages == [Dict(
         "role" => "user", "content" => [Dict("type" => "text", "text" => "Hello World")])]
-    @test schema2.model_id == "claude-3-5-sonnet-latest"
+    @test schema2.model_id == "claude-3-7-sonnet-latest"
 
     # Test aiprefill functionality
     schema2 = TestEchoAnthropicSchema(;
@@ -560,7 +560,7 @@ end
         Dict("role" => "assistant",
             "content" => [Dict("type" => "text", "text" => aiprefill)])
     ]
-    @test schema2.model_id == "claude-3-5-sonnet-latest"
+    @test schema2.model_id == "claude-3-7-sonnet-latest"
 
     # With caching
     response3 = Dict(
@@ -590,7 +590,7 @@ end
     @test schema3.inputs.messages == [Dict("role" => "user",
         "content" => Dict{String, Any}[Dict("cache_control" => Dict("type" => "ephemeral"),
             "text" => "Hello World", "type" => "text")])]
-    @test schema3.model_id == "claude-3-5-sonnet-latest"
+    @test schema3.model_id == "claude-3-7-sonnet-latest"
 
     ## Bad cache
     @test_throws AssertionError aigenerate(


### PR DESCRIPTION
- Added a OpenAI's GPT 4.5 research preview (alias `gpt45`) to the model registry.