### PR TITLE
Feat: Add Google Gemini Streaming Support

### DIFF
--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -17,7 +17,10 @@ function configure_callback!(cb::T, schema::AbstractPromptSchema;
         api_kwargs...) where {T <: AbstractStreamCallback}
     ## Check if we are in passthrough mode or if we should configure the callback
     if isnothing(cb.flavor)
-        if schema isa AbstractOpenAISchema
+        if schema isa GoogleOpenAISchema # it must come first because its a subtype of AbstractOpenAISchema
+            # api_kwargs = (; api_kwargs..., stream = true)
+            flavor = GoogleStream()
+        elseif schema isa AbstractOpenAISchema
             ## Enable streaming for all OpenAI-compatible APIs
             api_kwargs = (;
                 api_kwargs..., stream = true, stream_options = (; include_usage = true))

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -514,6 +514,7 @@ aliases = merge(
         "gem20f" => "gemini-2.0-flash",
         "gem20fl" => "gemini-2.0-flash-lite-preview-02-05",
         "gem20ft" => "gemini-2.0-flash-thinking-exp-01-21",
+        "gem25p" => "gemini-2.5-pro-exp-03-25",
         "gemexp" => "gemini-exp-1206" # latest experimental model from December 2024
     ),
     ## Load aliases from preferences as well
@@ -1311,7 +1312,12 @@ registry = Dict{String, ModelSpec}(
         GoogleOpenAISchema(),
         1.25e-6,
         5e-6,
-        "Gemini 2.0 Pro Experimental Model from February 2025. Pricing assumed as per Gemini 1.5 Pro. See details [here](https://ai.google.dev/gemini-api/docs/models/experimental-models#use-an-experimental-model).")
+        "Gemini 2.0 Pro Experimental Model from February 2025. Pricing assumed as per Gemini 1.5 Pro. See details [here](https://ai.google.dev/gemini-api/docs/models/experimental-models#use-an-experimental-model)."),
+    "gemini-2.5-pro-exp-03-25" => ModelSpec("gemini-2.5-pro-exp-03-25",
+        GoogleOpenAISchema(),
+        1.25e-6,
+        5e-6,
+        "Gemini 2.5 Pro Experimental Model from March 2025. Pricing assumed as per Gemini 1.5 Pro. See details [here](https://ai.google.dev/gemini-api/docs/models/experimental-models#use-an-experimental-model).")
 )
 
 """


### PR DESCRIPTION
This PR introduces streaming support for Google Gemini models via the . It includes necessary refactoring of payload conversion and updates API key handling in user preferences.