### PR TITLE
Remove hard-coded http for ollama

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a Deepwiki.com badge for AI-powered repo documentation.
 - Added Gemini 2.5 Flash Preview model from 20th May 2025 (alias `gem25f`).
 
+### Updated
+- Updated the OllamaManagedSchema to accept URLs with and without protocol to allow endpoints with `https://` (previously only `http://` was supported).
+
 ### Fixed
 
 ## [0.74.3]

--- a/src/llm_ollama_managed.jl
+++ b/src/llm_ollama_managed.jl
@@ -64,7 +64,7 @@ end
         endpoint::String = "generate",
         model::String = "llama2", http_kwargs::NamedTuple = NamedTuple(),
         stream::Bool = false,
-        url::String = "localhost", port::Int = 11434,
+        url::String = "http://localhost", port::Int = 11434,
         kwargs...)
 
 Simple wrapper for a call to Ollama API.
@@ -78,7 +78,7 @@ Simple wrapper for a call to Ollama API.
 - `http_kwargs::NamedTuple`: Additional keyword arguments for the HTTP request. Defaults to empty `NamedTuple`.
 - `stream`: A boolean indicating whether to stream the response. Defaults to `false`.
 - `streamcallback::Any`: A callback function to handle streaming responses. Can be simply `stdout` or a `StreamCallback` object. See `?StreamCallback` for details.
-- `url`: The URL of the Ollama API. Defaults to "localhost".
+- `url`: The URL of the Ollama API. Defaults to "http://localhost". If no protocol is specified, "http://" will be automatically added.
 - `port`: The port of the Ollama API. Defaults to 11434.
 - `kwargs`: Prompt variables to be used to fill the prompt/template
 """
@@ -91,7 +91,7 @@ function ollama_api(
         model::String = "llama2", http_kwargs::NamedTuple = NamedTuple(),
         streamcallback::Any = nothing,
         stream::Bool = false,
-        url::String = "localhost", port::Int = 11434,
+        url::String = "http://localhost", port::Int = 11434,
         kwargs...)
     @assert endpoint in ["chat", "generate", "embeddings"] "Only 'chat', 'generate' and 'embeddings' Ollama endpoints are supported."
     ##
@@ -106,7 +106,7 @@ function ollama_api(
         body["system"] = system
     end
     # eg, http://localhost:11434/api/generate
-    api_url = string(url, ":", port, "/api/", endpoint)
+    api_url = string(ensure_http_prefix(url), ":", port, "/api/", endpoint)
     if !isnothing(streamcallback)
         ## Note: Works only for OllamaSchema, not OllamaManagedSchema
         streamcallback, new_kwargs = configure_callback!(

--- a/src/llm_ollama_managed.jl
+++ b/src/llm_ollama_managed.jl
@@ -106,7 +106,7 @@ function ollama_api(
         body["system"] = system
     end
     # eg, http://localhost:11434/api/generate
-    api_url = string("http://", url, ":", port, "/api/", endpoint)
+    api_url = string(url, ":", port, "/api/", endpoint)
     if !isnothing(streamcallback)
         ## Note: Works only for OllamaSchema, not OllamaManagedSchema
         streamcallback, new_kwargs = configure_callback!(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -710,3 +710,31 @@ function extract_image_attributes(image_url::AbstractString)::Tuple{String, Stri
         throw(ArgumentError("Invalid data URL format"))
     end
 end
+
+"""
+    ensure_http_prefix(url::AbstractString) -> String
+
+Ensures that a URL has an HTTP or HTTPS protocol prefix. If the URL already starts with 
+"http://" or "https://", it is returned unchanged. Otherwise, "http://" is prepended.
+
+# Arguments
+- `url::AbstractString`: The URL to check and potentially modify.
+
+# Returns
+`String`: The URL with an appropriate protocol prefix.
+
+# Examples
+```julia
+ensure_http_prefix("localhost:8080")        # "http://localhost:8080"
+ensure_http_prefix("example.com")           # "http://example.com"
+ensure_http_prefix("http://localhost")      # "http://localhost"
+ensure_http_prefix("https://example.com")   # "https://example.com"
+```
+"""
+function ensure_http_prefix(url::AbstractString)::String
+    if startswith(url, "http://") || startswith(url, "https://")
+        return String(url)
+    else
+        return "http://" * url
+    end
+end


### PR DESCRIPTION
This allows including https in the url endpoint. 

It may break endpoints for projects that assume the ollama api makes post requests via http.