### PR TITLE
Model listing in the MODEL_REGISTRY documentation

### DIFF
--- a/test/user_preferences.jl
+++ b/test/user_preferences.jl
@@ -125,4 +125,25 @@ end
     # list functions
     @test list_registry() == sort(collect(keys(MODEL_REGISTRY.registry)))
     @test list_aliases() == MODEL_REGISTRY.aliases
+
+    struct A <: PT.AbstractPromptSchema end
+    struct B <: PT.AbstractPromptSchema end
+
+    m = PT.ModelRegistry(
+        Dict("aa" => ModelSpec(name = "aa", schema = A()),
+            "aa2" => ModelSpec(name = "aa2", schema = A()),
+            "bb" => ModelSpec(name = "bb", schema = B())),
+        Dict("a" => "aa", "b" => "bb", "b2" => "bb")
+    )
+
+    @test keys(m) == Set(["aa2", "bb", "b", "b2", "aa", "a"])
+    @test PT.model_docs(m) ==
+          """
+          ## A
+          - `aa2`
+          - `aa` - aliases: `a`
+
+          ## B
+          - `bb` - aliases: `b` and `b2`
+          """ # sorted, multiple aliases, multiple schemas, multiple models for single schema
 end


### PR DESCRIPTION
Sorry for the convoluted code. It cannot be too much better though since we are doing two dict reversions with non-unique keys. Here is the result of the documentation:

```julia
help?> ?PT.MODEL_REGISTRY
  │ Warning
  │
  │  The following bindings may be internal; they may change or be removed in future versions:
  │
  │    •  PromptingTools.MODEL_REGISTRY

  MODEL_REGISTRY

  A store of available model names and their specs (ie, name, costs per token, etc.)

  Accessing the registry
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  You can use both the alias name or the full name to access the model spec:

  PromptingTools.MODEL_REGISTRY["gpt-3.5-turbo"]

  Registering a new model
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  register_model!(
      name = "gpt-3.5-turbo",
      schema = :OpenAISchema,
      cost_of_token_prompt = 0.0015,
      cost_of_token_generation = 0.002,
      description = "GPT-3.5 Turbo is a 175B parameter model and a common default on the OpenAI API.")

  Registering a model alias
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  PromptingTools.MODEL_ALIASES["gpt3"] = "gpt-3.5-turbo"

  Extended help
  ≡≡≡≡≡≡≡≡≡≡≡≡≡

  AnthropicSchema
  ===============

    •  claude-3-5-haiku-latest - aliases: claudeh
    •  claude-sonnet-4-20250514 - aliases: claude4, claude and claudes
    •  claude-3-5-haiku-20241022
    •  claude-3-opus-20240229
    •  claude-2.1
    •  claude-3-5-sonnet-latest - aliases: claude35
    •  claude-3-7-sonnet-latest - aliases: claude37
    •  claude-opus-4-20250514 - aliases: claudeo
    •  claude-3-5-sonnet-20241022
    •  claude-3-haiku-20240307
    •  claude-3-7-sonnet-20250219
    •  claude-3-sonnet-20240229
    •  claude-3-5-sonnet-20240620

  CerebrasOpenAISchema
  ====================

    •  llama3.1-70b - aliases: cl70 and cllama70
    •  llama3.1-8b - aliases: cl3 and cllama3

  DeepSeekOpenAISchema
  ====================

    •  deepseek-chat - aliases: dschat and ds
    •  deepseek-reasoner - aliases: dsr and dsreason
    •  deepseek-coder - aliases: dscode

  FireworksOpenAISchema
  =====================

    •  accounts/fireworks/models/dbrx-instruct
    •  accounts/fireworks/models/firefunction-v1 - aliases: firefunction
    •  accounts/fireworks/models/mixtral-8x22b-instruct-preview
    •  accounts/fireworks/models/qwen2p5-coder-32b-instruct - aliases: fqwen25c
    •  accounts/fireworks/models/llama-v3p1-8b-instruct - aliases: fllama3 and fls
    •  accounts/fireworks/models/mixtral-8x7b-instruct - aliases: fmixtral
    •  accounts/fireworks/models/qwen-72b-chat
    •  accounts/fireworks/models/llama-v3p1-70b-instruct - aliases: fllama370 and flm
    •  accounts/fireworks/models/deepseek-v3 - aliases: fds
    •  accounts/fireworks/models/llama-v3p1-405b-instruct - aliases: fll and fllama3405

  GoogleOpenAISchema
  ==================

    •  gemini-2.0-flash-lite-preview-02-05 - aliases: gem20fl
    •  gemini-exp-1114
    •  gemini-2.0-pro-exp-02-05 - aliases: gem20p
    •  gemini-1.5-pro-latest - aliases: gem15p
    •  gemini-2.0-flash-exp
    •  gemini-2.5-pro-preview-05-06 - aliases: gem25p
    •  gemini-2.5-flash-preview-04-17
    •  gemini-1.5-flash-latest - aliases: gem15f
    •  gemini-2.0-flash-thinking-exp-01-21 - aliases: gem20ft
    •  gemini-exp-1121
    •  gemini-exp-1206 - aliases: gemexp
    •  gemini-2.0-flash - aliases: gem20f
    •  gemini-2.5-flash-preview-05-20 - aliases: gem25f
    •  gemini-1.5-flash-8b-latest - aliases: gem15f8

  GoogleSchema
  ============

    •  gemini-pro - aliases: gemini

  GroqOpenAISchema
  ================

    •  mixtral-8x7b-32768 - aliases: gmixtral
    •  llama-3.1-8b-instant - aliases: gllama3, gl3 and gls
    •  moonshotai/kimi-k2-instruct - aliases: gk2
    •  llama3-70b-8192
    •  llama-3.3-70b-specdec - aliases: gl70s and glms
    •  llama3-groq-70b-8192-tool-use-preview - aliases: glmt
    •  llama-3.3-70b-versatile - aliases: gl70, glm and gllama370
    •  llama-3.2-90b-vision-preview - aliases: glmv
    •  llama-3.2-11b-vision-preview - aliases: glsv
    •  llama3-groq-8b-8192-tool-use-preview - aliases: glst
    •  gemma2-9b-it - aliases: ggemma9
    •  llama3-8b-8192
    •  llama-3.2-3b-preview - aliases: glxs
    •  llama-3.1-70b-versatile
    •  llama-3.2-1b-preview - aliases: glxxs
    •  DeepSeek-R1-Distill-Llama-70b - aliases: glmr
    •  llama-3.1-405b-reasoning - aliases: gll, gllama3405 and gl405
    •  llama-guard-3-8b - aliases: glguard

  LocalServerOpenAISchema
  =======================

    •  local-server - aliases: local
    •  custom

  MiniMaxOpenAISchema
  ===================

    •  MiniMax-Text-01 - aliases: minimax

  MistralOpenAISchema
  ===================

    •  codestral-2405
    •  mistral-medium-latest - aliases: mistral-medium and mistralm
    •  mistral-tiny-2312
    •  codestral-latest - aliases: mistralc and codestral
    •  ministral-8b-2410
    •  ministral-3b-latest - aliases: ministral3
    •  mistral-embed
    •  mistral-large-latest - aliases: mistrall and mistral-large
    •  mistral-large-2402
    •  open-mistral-7b
    •  mistral-medium-2312
    •  mistral-small-latest - aliases: mistrals and mistral-small
    •  mistral-large-2407
    •  open-mixtral-8x7b
    •  ministral-3b-2410
    •  mistral-tiny - aliases: mistralt and mistral-tiny
    •  open-mistral-nemo-2407
    •  mistral-small-2402
    •  ministral-8b-latest - aliases: ministral8
    •  open-mistral-nemo - aliases: mistraln and mistral-nemo

  MoonshotOpenAISchema
  ====================

    •  kimi-k2-0711-preview - aliases: k2

  OllamaSchema
  ============

    •  nomic-embed-text
    •  yi:34b-chat - aliases: yi34c
    •  bakllava
    •  mxbai-embed-large
    •  llava
    •  llama3:8b-instruct-q5_K_S - aliases: llama3 and ollama3
    •  llama2
    •  starling-lm - aliases: starling
    •  wizardlm2:7b-q5_K_S
    •  openhermes2.5-mistral - aliases: oh25

  OpenAISchema
  ============

    •  o4-mini-2025-04-16 - aliases: o4m
    •  o3-2025-04-16 - aliases: o3
    •  dall-e-2
    •  gpt-4.5-preview-2025-02-27
    •  o1-preview - aliases: o1p
    •  gpt-4-turbo - aliases: gpt4t
    •  text-embedding-3-small - aliases: emb3small
    •  o1-mini - aliases: o1m
    •  gpt-4 - aliases: gpt4
    •  gpt-4o - aliases: gpt4o
    •  gpt-4o-2024-08-06 - aliases: gpt4ol
    •  o1-2024-12-17
    •  gpt-4.1-nano-2025-04-14 - aliases: gpt41n
    •  o3-mini - aliases: o3m
    •  gpt-4-1106-preview
    •  gpt-4.1-2025-04-14 - aliases: gpt41
    •  dall-e-3
    •  text-embedding-ada-002 - aliases: ada
    •  gpt-4o-2024-05-13
    •  gpt-4o-mini - aliases: gpt4om
    •  o3-mini-2025-01-31
    •  gpt-4.5-preview - aliases: gpt45
    •  gpt-4-0125-preview
    •  o1 - aliases: o1
    •  gpt-4o-mini-2024-07-18
    •  text-embedding-3-large - aliases: emb3large
    •  gpt-4-turbo-preview
    •  gpt-4-vision-preview - aliases: gpt4v
    •  o1-preview-2024-09-12
    •  gpt-4-turbo-2024-04-09
    •  gpt-3.5-turbo-1106
    •  o1-mini-2024-09-12
    •  gpt-4.1-mini-2025-04-14 - aliases: gpt41m
    •  gpt-3.5-turbo-0125 - aliases: gpt3t
    •  gpt-3.5-turbo - aliases: gpt3
    •  chatgpt-4o-latest - aliases: chatgpt

  OpenRouterOpenAISchema
  ======================

    •  qwen/qwen-max - aliases: orqwenmax
    •  openai/o1-preview - aliases: oro1
    •  openai/o1-mini-2024-09-12
    •  cohere/command-r-08-2024 - aliases: orco
    •  qwen/qwen-turbo - aliases: orqwenturbo
    •  cohere/command-r-plus-08-2024 - aliases: orcop
    •  openai/o1-mini - aliases: oro1m
    •  qwen/qwen-plus - aliases: orqwenplus
    •  google/gemini-flash-1.5-8b - aliases: orgf8b
    •  google/gemini-flash-1.5 - aliases: orgf
    •  meta-llama/llama-3.1-405b
    •  openai/o1-preview-2024-09-12

  SambaNovaOpenAISchema
  =====================

    •  Meta-Llama-3.2-3B-Instruct - aliases: sl3b and slxxs
    •  Meta-Llama-3.2-1B-Instruct - aliases: slxs and sl1
    •  Meta-Llama-3.1-70B-Instruct - aliases: sllama70, slm and sl70
    •  Meta-Llama-3.1-405B-Instruct - aliases: sll, sllama405 and sl405
    •  Meta-Llama-3.1-8B-Instruct - aliases: sl3, sls and sllama3

  TestEchoOpenAISchema
  ====================

    •  echo

  TogetherOpenAISchema
  ====================

    •  Qwen/Qwen2.5-Coder-32B-Instruct - aliases: tqwen25c
    •  meta-llama/Llama-3-8b-chat-hf
    •  meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo - aliases: tlm and tllama370
    •  deepseek-ai/DeepSeek-V3 - aliases: tds
    •  meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo - aliases: tls and tllama3
    •  mistralai/Mixtral-8x7B-Instruct-v0.1 - aliases: tmixtral
    •  mistralai/Mixtral-8x22B-Instruct-v0.1 - aliases: tmixtral22
    •  meta-llama/Llama-3-70b-chat-hf
    •  Qwen/QwQ-32B-Preview
    •  Qwen/Qwen2.5-7B-Instruct-Turbo - aliases: tqwen25b7
    •  Qwen/Qwen2.5-72B-Instruct-Turbo - aliases: tqwen25b72
    •  meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo - aliases: tllama3405 and tll

  XAIOpenAISchema
  ===============

    •  grok-beta - aliases: grok
    •  grok-4-0709 - aliases: grok4
help?> keys(PT.MODEL_REGISTRY)
  │ Warning
  │
  │  The following bindings may be internal; they may change or be removed in future versions:
  │
  │    •  PromptingTools.MODEL_REGISTRY

  keys(m::ModelRegistry)

  Returns all the model names and aliases that are available from the registry.
```
Closes #299 