### PR TITLE
Add xAI Grok 4 Fast models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for xAI's Grok 4 Fast models (`grok-4-fast-reasoning`, alias `grok4fr`, and `grok-4-fast-non-reasoning`, alias `grok4f`) featuring 2M token context windows and competitive pricing.
 
+### Updated
+- Cleaned up the `Experimental.RAGTools` module stub. You can find the functionality in the [RAGTools.jl](https://github.com/JuliaGenAI/RAGTools.jl) package.
+
 ## [0.81.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
+## [0.82.0]
+
+### Added
+- Added support for xAI's Grok 4 Fast models (`grok-4-fast-reasoning`, alias `grok4fr`, and `grok-4-fast-non-reasoning`, alias `grok4f`) featuring 2M token context windows and competitive pricing.
+
 ## [0.81.1]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ default: help
 
 format:
 	# assumes you have JuliaFormatter installed in your global env / somewhere on LOAD_PATH
-	julia -e 'using JuliaFormatter; format(".")'
+	julia --project=@Fmt -e 'using JuliaFormatter; format(".")'
 
+test:
+	julia --project=. -e 'using Pkg; Pkg.test()'
 
 help:
 	echo "make help - show this help"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PromptingTools"
 uuid = "670122d1-24a8-4d70-bfce-740807c42192"
 authors = ["J S @svilupp and contributors"]
-version = "0.81.1"
+version = "0.82.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/Experimental/Experimental.jl
+++ b/src/Experimental/Experimental.jl
@@ -5,17 +5,16 @@ This module is for experimental code that is not yet ready for production.
 It is not included in the main module, so it must be explicitly imported.
 
 Contains:
-- `RAGTools`: [DEPRECATED] RAG functionality has moved to RAGTools.jl package.
 - `AgentTools`: Agentic functionality - lazy calls for building pipelines (eg, `AIGenerate`) and `AICodeFixer`.
 - `APITools`: APIs to complement GenAI workflows (eg, Tavily Search API).
+
+Removed:
+- `RAGTools`: RAG functionality has moved to [RAGTools.jl](https://github.com/JuliaGenAI/RAGTools.jl) package.
 """
 module Experimental
 
 export APITools
 include("APITools/APITools.jl")
-
-export RAGTools
-include("RAGTools.jl")
 
 export AgentTools
 include("AgentTools/AgentTools.jl")

--- a/src/Experimental/RAGTools.jl
+++ b/src/Experimental/RAGTools.jl
@@ -1,6 +1,4 @@
-module RAGTools
-
-@warn """
+"""
 RAGTools functionality has moved to a dedicated package!
 
 The PromptingTools.Experimental.RAGTools module has been moved to the separate RAGTools.jl package.
@@ -11,6 +9,7 @@ To migrate your code:
 3. All function names and APIs remain the same
 
 For more information, visit: https://github.com/JuliaGenAI/RAGTools.jl
-""" maxlog=1
+"""
+module RAGTools
 
 end # module RAGTools

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -510,6 +510,8 @@ aliases = merge(
         ## XAI's Grok
         "grok" => "grok-beta",
         "grok4" => "grok-4-0709",
+        "grok4fr" => "grok-4-fast-reasoning",
+        "grok4f" => "grok-4-fast-non-reasoning",
         ## MiniMax
         "minimax" => "MiniMax-Text-01",
         ## DeepSeek
@@ -1376,6 +1378,16 @@ registry = Dict{String, ModelSpec}(
         3e-6,
         15e-6,
         "XAI's Grok 4 model with 256K context window, vision, function calling, and reasoning capabilities."),
+    "grok-4-fast-reasoning" => ModelSpec("grok-4-fast-reasoning",
+        XAIOpenAISchema(),
+        2e-7,
+        5e-7,
+        "XAI's Grok 4 Fast Reasoning model featuring a 2M token context window with optimized reasoning performance."),
+    "grok-4-fast-non-reasoning" => ModelSpec("grok-4-fast-non-reasoning",
+        XAIOpenAISchema(),
+        2e-7,
+        5e-7,
+        "XAI's Grok 4 Fast Non-Reasoning model with a 2M token context window optimized for general-purpose generation."),
     "grok-code-fast-1" => ModelSpec("grok-code-fast-1",
         XAIOpenAISchema(),
         2e-7,


### PR DESCRIPTION
### Added
- Added support for xAI's Grok 4 Fast models (`grok-4-fast-reasoning`, alias `grok4fr`, and `grok-4-fast-non-reasoning`, alias `grok4f`) featuring 2M token context windows and competitive pricing.

### Updated
- Cleaned up the `Experimental.RAGTools` module stub. You can find the functionality in the [RAGTools.jl](https://github.com/JuliaGenAI/RAGTools.jl) package.